### PR TITLE
Keep timezone in string formatting of Interval

### DIFF
--- a/src/main/java/org/joda/time/base/AbstractInterval.java
+++ b/src/main/java/org/joda/time/base/AbstractInterval.java
@@ -480,7 +480,7 @@ public abstract class AbstractInterval implements ReadableInterval {
      * @return re-parsable string
      */
     public String toString() {
-        DateTimeFormatter printer = ISODateTimeFormat.dateHourMinuteSecondFraction();
+        DateTimeFormatter printer = ISODateTimeFormat.dateTime();
         printer = printer.withChronology(getChronology());
         StringBuffer buf = new StringBuffer(48);
         printer.printTo(buf, getStartMillis());

--- a/src/test/java/org/joda/time/TestInterval_Basics.java
+++ b/src/test/java/org/joda/time/TestInterval_Basics.java
@@ -1037,7 +1037,7 @@ public class TestInterval_Basics extends TestCase {
         DateTime dt1 = new DateTime(2004, 6, 9, 7, 8, 9, 10, DateTimeZone.UTC);
         DateTime dt2 = new DateTime(2005, 8, 13, 12, 14, 16, 18, DateTimeZone.UTC);
         Interval test = new Interval(dt1, dt2);
-        assertEquals("2004-06-09T07:08:09.010/2005-08-13T12:14:16.018", test.toString());
+        assertEquals("2004-06-09T07:08:09.010Z/2005-08-13T12:14:16.018Z", test.toString());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/joda/time/TestMutableInterval_Basics.java
+++ b/src/test/java/org/joda/time/TestMutableInterval_Basics.java
@@ -468,7 +468,7 @@ public class TestMutableInterval_Basics extends TestCase {
         DateTime dt1 = new DateTime(2004, 6, 9, 7, 8, 9, 10, DateTimeZone.UTC);
         DateTime dt2 = new DateTime(2005, 8, 13, 12, 14, 16, 18, DateTimeZone.UTC);
         MutableInterval test = new MutableInterval(dt1, dt2);
-        assertEquals("2004-06-09T07:08:09.010/2005-08-13T12:14:16.018", test.toString());
+        assertEquals("2004-06-09T07:08:09.010Z/2005-08-13T12:14:16.018Z", test.toString());
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Format the endpoints of an interval in toString using ISODateTimeFormat.dateTime(), to not lose the timezone
