### PR TITLE
Deterministic hashCode from DurationFieldType

### DIFF
--- a/src/main/java/org/joda/time/DurationFieldType.java
+++ b/src/main/java/org/joda/time/DurationFieldType.java
@@ -331,5 +331,9 @@ public abstract class DurationFieldType implements Serializable {
             }
         }
 
+	@Override
+	public int hashCode() {
+	    return new Integer(iOrdinal).hashCode();
+	}
     }
 }


### PR DESCRIPTION
Hey Maintainer!,

This patch makes hashCodes of DurationFieldType deterministic.  It's nice if hashCodes are deterministic, because then behavior that depends on hashCode can be reproduced.  This patch also makes the hashCode of Period deterministic, which is how I first noticed the issue.

Thanks!,

-- Ned Ruggeri
