### PR TITLE
Fix Duration conversion from String for negative millisecond durations.

### DIFF
--- a/src/main/java/org/joda/time/convert/StringConverter.java
+++ b/src/main/java/org/joda/time/convert/StringConverter.java
@@ -112,11 +112,14 @@ class StringConverter extends AbstractConverter
         }
         str = str.substring(2, len - 1);
         int dot = -1;
+        boolean negative = false;
         for (int i = 0; i < str.length(); i++) {
-            if ((str.charAt(i) >= '0' && str.charAt(i) <= '9') ||
-                (i == 0 && str.charAt(0) == '-')) {
+            if (str.charAt(i) >= '0' && str.charAt(i) <= '9') {
                 // ok
-            } else if (i > 0 && str.charAt(i) == '.' && dot == -1) {
+            } else if (i == 0 && str.charAt(0) == '-') {
+            	// ok
+            	negative = true;
+            } else if (i > (negative ? 1 : 0) && str.charAt(i) == '.' && dot == -1) {
                 // ok
                 dot = i;
             } else {
@@ -124,18 +127,23 @@ class StringConverter extends AbstractConverter
             }
         }
         long millis = 0, seconds = 0;
+        int firstDigit = negative ? 1 : 0;
         if (dot > 0) {
-            seconds = Long.parseLong(str.substring(0, dot));
+            seconds = Long.parseLong(str.substring(firstDigit, dot));
             str = str.substring(dot + 1);
             if (str.length() != 3) {
                 str = (str + "000").substring(0, 3);
             }
             millis = Integer.parseInt(str);
-        } else {
+        } else if (negative) {
+        	seconds = Long.parseLong(str.substring(firstDigit, str.length()));
+        }
+        else {
             seconds = Long.parseLong(str);
         }
-        if (seconds < 0) {
-            return FieldUtils.safeAdd(FieldUtils.safeMultiply(seconds, 1000), -millis);
+        assert(seconds >= 0L);
+        if (negative) {
+            return FieldUtils.safeAdd(FieldUtils.safeMultiply(-seconds, 1000), -millis);
         } else {
             return FieldUtils.safeAdd(FieldUtils.safeMultiply(seconds, 1000), millis);
         }

--- a/src/test/java/org/joda/time/convert/TestStringConverter.java
+++ b/src/test/java/org/joda/time/convert/TestStringConverter.java
@@ -302,6 +302,15 @@ public class TestStringConverter extends TestCase {
         millis = StringConverter.INSTANCE.getDurationMillis("pt-12.32s");
         assertEquals(-12320, millis);
         
+        millis = StringConverter.INSTANCE.getDurationMillis("pt-0.32s");
+        assertEquals(-320, millis);
+
+        millis = StringConverter.INSTANCE.getDurationMillis("pt-0.0s");
+        assertEquals(0, millis);
+
+        millis = StringConverter.INSTANCE.getDurationMillis("pt0.0s");
+        assertEquals(0, millis);
+
         millis = StringConverter.INSTANCE.getDurationMillis("pt12.3456s");
         assertEquals(12345, millis);
     }
@@ -337,6 +346,10 @@ public class TestStringConverter extends TestCase {
         } catch (IllegalArgumentException ex) {}
         try {
             StringConverter.INSTANCE.getDurationMillis("PT0-00S");
+            fail();
+        } catch (IllegalArgumentException ex) {}
+        try {
+            StringConverter.INSTANCE.getDurationMillis("PT-.001S");
             fail();
         } catch (IllegalArgumentException ex) {}
     }


### PR DESCRIPTION
### Problem

While conversions of negative durations <= -1 second work

```
(new Duration("PT-1.001S")).getMillis == -1001L
```

they fail for negative durations between zero and -1 second:

```
(new Duration("PT-0.001S")).getMillis == 1L
```

(should be -1L instead).
### Fix

The attached code fixes that.
See Test class changes for some examples.
