### PR TITLE
Deprecate DateMidnight

### DIFF
--- a/src/main/java/org/joda/time/DateMidnight.java
+++ b/src/main/java/org/joda/time/DateMidnight.java
@@ -67,7 +67,13 @@ import org.joda.time.format.ISODateTimeFormat;
  *
  * @author Stephen Colebourne
  * @since 1.0
+ * @deprecated The time of midnight does not exist in some time zones
+ * where the daylight saving time forward shift skips the midnight hour.
+ * Use {@link LocalDate} to represent a date without a time zone
+ * and {@link DateTime#withTimeAtStartOfDay()} to get an instant at the
+ * start of a day.
  */
+@Deprecated
 public final class DateMidnight
         extends BaseDateTime
         implements ReadableDateTime, Serializable {


### PR DESCRIPTION
The comment on `LocalDate#toDateMidnight` already indicates that `DateMidnight` is to be avoided and why.
This makes it explicit.
