### PR TITLE
ThreadGroup.uncaughtException() should not be called from library code.

### DIFF
--- a/src/main/java/org/joda/time/DateTimeZone.java
+++ b/src/main/java/org/joda/time/DateTimeZone.java
@@ -477,8 +477,7 @@ public abstract class DateTimeZone implements Serializable {
                 try {
                     provider = (Provider) Class.forName(providerClass).newInstance();
                 } catch (Exception ex) {
-                    Thread thread = Thread.currentThread();
-                    thread.getThreadGroup().uncaughtException(thread, ex);
+                    ex.printStackTrace();
                 }
             }
         } catch (SecurityException ex) {
@@ -489,8 +488,7 @@ public abstract class DateTimeZone implements Serializable {
             try {
                 provider = new ZoneInfoProvider("org/joda/time/tz/data");
             } catch (Exception ex) {
-                Thread thread = Thread.currentThread();
-                thread.getThreadGroup().uncaughtException(thread, ex);
+                ex.printStackTrace();
             }
         }
 
@@ -561,8 +559,7 @@ public abstract class DateTimeZone implements Serializable {
                 try {
                     nameProvider = (NameProvider) Class.forName(providerClass).newInstance();
                 } catch (Exception ex) {
-                    Thread thread = Thread.currentThread();
-                    thread.getThreadGroup().uncaughtException(thread, ex);
+                    ex.printStackTrace();
                 }
             }
         } catch (SecurityException ex) {

--- a/src/main/java/org/joda/time/tz/ZoneInfoProvider.java
+++ b/src/main/java/org/joda/time/tz/ZoneInfoProvider.java
@@ -175,16 +175,6 @@ public class ZoneInfoProvider implements Provider {
     }
 
     /**
-     * Called if an exception is thrown from getZone while loading zone data.
-     * 
-     * @param ex  the exception
-     */
-    protected void uncaughtException(Exception ex) {
-        Thread t = Thread.currentThread();
-        t.getThreadGroup().uncaughtException(t, ex);
-    }
-
-    /**
      * Opens a resource from file or classpath.
      * 
      * @param name  the name to open
@@ -229,7 +219,7 @@ public class ZoneInfoProvider implements Provider {
             iZoneInfoMap.put(id, new SoftReference<DateTimeZone>(tz));
             return tz;
         } catch (IOException ex) {
-            uncaughtException(ex);
+            ex.printStackTrace();
             iZoneInfoMap.remove(id);
             return null;
         } finally {


### PR DESCRIPTION
It seems to me that it is incorrect to be calling uncaughtException(...) from library code. Implementors of this method (or of UncaughtExceptionHandler) will only be expecting to be called by the JVM when an exception has propagated up the entire thread stack and the thread is terminating.

> Called by the Java Virtual Machine when a thread in this thread group stops because of an uncaught exception, and the thread does not have a specific Thread.UncaughtExceptionHandler installed.

In this changeset I've replaced these calls with logging of the exceptions to System.err (which is what the default uncaughtException implementation will do).  If this is not what people think is the best replacement here then we could substitute this for say JDK logging, or we could swallow the exception completely. I'm also open to refining the text of what is logged. This push request was just intended as the minimal change that replicates the behavior I think the author wanted to get a yay or nay on the change in principle.
