### PR TITLE
Caches should not be serialized

### DIFF
--- a/src/main/java/org/joda/time/tz/CachedDateTimeZone.java
+++ b/src/main/java/org/joda/time/tz/CachedDateTimeZone.java
@@ -81,7 +81,7 @@ public class CachedDateTimeZone extends DateTimeZone {
 
     private final DateTimeZone iZone;
 
-    private final Info[] iInfoCache = new Info[cInfoCacheMask + 1];
+    private final transient Info[] iInfoCache = new Info[cInfoCacheMask + 1];
 
     private CachedDateTimeZone(DateTimeZone zone) {
         super(zone.getID());


### PR DESCRIPTION
Hello!
I faced this bug https://github.com/JodaOrg/joda-time/issues/46 too.

 Caused by: java.io.NotSerializableException: org.joda.time.tz.CachedDateTimeZone$Info
    at java.io.ObjectOutputStream.writeNewObject(ObjectOutputStream.java:1364)
    at java.io.ObjectOutputStream.writeObjectInternal(ObjectOutputStream.java:1671)
    at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:1517)
    at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:1481)
    at java.io.ObjectOutputStream.writeNewArray(ObjectOutputStream.java:1205)
    at java.io.ObjectOutputStream.writeObjectInternal(ObjectOutputStream.java:1662)
    at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:1517)
    at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:1481)
    at java.io.ObjectOutputStream.writeFieldValues(ObjectOutputStream.java:979)
    at java.io.ObjectOutputStream.defaultWriteObject(ObjectOutputStream.java:368)
    at java.io.ObjectOutputStream.writeHierarchy(ObjectOutputStream.java:1074)
    at java.io.ObjectOutputStream.writeNewObject(ObjectOutputStream.java:1404)
    at java.io.ObjectOutputStream.writeObjectInternal(ObjectOutputStream.java:1671)
    at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:1517)
    at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:1481)
    at java

As I can see it is caused by trying to serialize cache field of non serializable class. I think that it should not be serialized.
My fix passes all tests and solves this problem.
Thank you in advance for reviewing it.
