### PR TITLE
Canonically order partial fields to allow comparison

### DIFF
--- a/src/main/java/org/joda/time/ReadablePartial.java
+++ b/src/main/java/org/joda/time/ReadablePartial.java
@@ -59,6 +59,7 @@ public interface ReadablePartial extends Comparable<ReadablePartial> {
      * @param index  the index to retrieve
      * @return the field at the specified index
      * @throws IndexOutOfBoundsException if the index is invalid
+     * @see ReadablePartial#getOrderedFieldType(int)
      */
     DateTimeField getField(int index);
 
@@ -68,8 +69,29 @@ public interface ReadablePartial extends Comparable<ReadablePartial> {
      * @param index  the index to retrieve
      * @return the value of the field at the specified index
      * @throws IndexOutOfBoundsException if the index is invalid
+     * @see ReadablePartial#getOrderedValue(int)
      */
     int getValue(int index);
+
+    /**
+     * Gets the field type at the specified index in the canonical ordering.
+     *
+     * @param index  the index to retrieve
+     * @return the field at the specified index
+     * @throws IndexOutOfBoundsException if the index is invalid
+     * @see ReadablePartial#getFieldType(int)
+     */
+    DateTimeFieldType getOrderedFieldType(int index);
+
+    /**
+     * Gets the value at the specified index in the canonical ordering.
+     *
+     * @param index  the index to retrieve
+     * @return the value of the field at the specified index
+     * @throws IndexOutOfBoundsException if the index is invalid
+     * @see ReadablePartial#getValue(int)
+     */
+    int getOrderedValue(int index);
 
     /**
      * Gets the chronology of the partial which is never null.

--- a/src/main/java/org/joda/time/base/AbstractPartial.java
+++ b/src/main/java/org/joda/time/base/AbstractPartial.java
@@ -80,6 +80,17 @@ public abstract class AbstractPartial
     }
 
     /**
+     * Gets the field type at the specified index in the canonical ordering.
+     *
+     * @param index  the index to retrieve
+     * @return the field type
+     * @see AbstractPartial#getFieldType(int)
+     */
+    public DateTimeFieldType getOrderedFieldType(int index) {
+        return getFieldType(index);
+    }
+
+    /**
      * Gets an array of the field types that this partial supports.
      * <p>
      * The fields are returned largest to smallest, for example Hour, Minute, Second.
@@ -134,6 +145,17 @@ public abstract class AbstractPartial
             result[i] = getValue(i);
         }
         return result;
+    }
+
+    /**
+     * Gets the value at the specified index in the canonical ordering.
+     *
+     * @param index  the index to retrieve
+     * @return the value of the field at the specified index
+     * @see AbstractPartial#getValue(int)
+     */
+    public int getOrderedValue(int index) {
+        return getValue(index);
     }
 
     //-----------------------------------------------------------------------
@@ -263,7 +285,7 @@ public abstract class AbstractPartial
             return false;
         }
         for (int i = 0, isize = size(); i < isize; i++) {
-            if (getValue(i) != other.getValue(i) || getFieldType(i) != other.getFieldType(i)) {
+            if (getOrderedValue(i) != other.getOrderedValue(i) || getOrderedFieldType(i) != other.getOrderedFieldType(i)) {
                 return false;
             }
         }
@@ -315,16 +337,16 @@ public abstract class AbstractPartial
             throw new ClassCastException("ReadablePartial objects must have matching field types");
         }
         for (int i = 0, isize = size(); i < isize; i++) {
-            if (getFieldType(i) != other.getFieldType(i)) {
+            if (getOrderedFieldType(i) != other.getOrderedFieldType(i)) {
                 throw new ClassCastException("ReadablePartial objects must have matching field types");
             }
         }
         // fields are ordered largest first
         for (int i = 0, isize = size(); i < isize; i++) {
-            if (getValue(i) > other.getValue(i)) {
+            if (getOrderedValue(i) > other.getOrderedValue(i)) {
                 return 1;
             }
-            if (getValue(i) < other.getValue(i)) {
+            if (getOrderedValue(i) < other.getOrderedValue(i)) {
                 return -1;
             }
         }

--- a/src/test/java/org/joda/time/MockPartial.java
+++ b/src/test/java/org/joda/time/MockPartial.java
@@ -41,6 +41,12 @@ public class MockPartial implements ReadablePartial {
     public int getValue(int index) {
         return getValues()[index];
     }
+    public DateTimeFieldType getOrderedFieldType(int index) {
+        return getFieldType(index);
+    }
+    public int getOrderedValue(int index) {
+        return getValue(index);
+    }
     public int get(DateTimeFieldType field) {
         return 0;
     }

--- a/src/test/java/org/joda/time/TestPartial_Basics.java
+++ b/src/test/java/org/joda/time/TestPartial_Basics.java
@@ -244,6 +244,20 @@ public class TestPartial_Basics extends TestCase {
     }
 
     //-----------------------------------------------------------------------
+    public void testCompareToForFieldsWithDifferentDurationsThatCompareAsZeroWithOneNullDurationRange() {
+        Partial partial1 = new Partial(
+                new DateTimeFieldType[] {DateTimeFieldType.yearOfCentury(), DateTimeFieldType.weekyear()},
+                new int [] { 0, 0 }
+        );
+        Partial partial2 = new Partial(
+                new DateTimeFieldType[] {DateTimeFieldType.weekyear(), DateTimeFieldType.yearOfCentury()},
+                new int [] { 0, 0 }
+        );
+        assertEquals(0, partial1.compareTo(partial2));
+        assertEquals(0, partial2.compareTo(partial1));
+    }
+
+    //-----------------------------------------------------------------------
     public void testIsEqual_TOD() {
         Partial test1 = createHourMinPartial();
         Partial test1a = createHourMinPartial();
@@ -260,13 +274,27 @@ public class TestPartial_Basics extends TestCase {
         assertEquals(false, test1.isEqual(test3));
         assertEquals(false, test3.isEqual(test1));
         assertEquals(true, test3.isEqual(test2));
-        
+
         try {
             createHourMinPartial().isEqual(null);
             fail();
         } catch (IllegalArgumentException ex) {}
     }
-    
+
+    //-----------------------------------------------------------------------
+    public void testEqualsForFieldsWithDifferentDurationsThatCompareAsZeroWithOneNullDurationRange() {
+        Partial partial1 = new Partial(
+                new DateTimeFieldType[] {DateTimeFieldType.yearOfCentury(), DateTimeFieldType.weekyear()},
+                new int [] { 0, 0 }
+        );
+        Partial partial2 = new Partial(
+                new DateTimeFieldType[] {DateTimeFieldType.weekyear(), DateTimeFieldType.yearOfCentury()},
+                new int [] { 0, 0 }
+        );
+        assertEquals(true, partial1.equals(partial2));
+        assertEquals(true, partial2.equals(partial1));
+    }
+
     //-----------------------------------------------------------------------
     public void testIsBefore_TOD() {
         Partial test1 = createHourMinPartial();


### PR DESCRIPTION
Hi,

Issue #96 describes a problem in which Partials made from equal (but differently ordered) fields are not considered equal. This change fixes that (and adds tests to support the fix) by enforcing a canonical ordering of fields on construction of the Partial.

I'm not certain that this is better than disallowing the construction - in particular, I don't know if it will have any unintended side-effects (but it doesn't break any tests). I'm also not keen on the large amounts of logic about ordering DateTimeFieldTypes now collected in the Partial class (and its new private comparator) - if there's an obviously better place for it to go, please let me know.

As far as I can tell, the only affected case is where a) the fields are similar in that compareTo() returns 0, but different in that equals() returns false and b) one of the fields has a range duration and the other does not. I've ordered such fields on their name.

I _think_ in all other cases the Partial constructor will reject the fields as being either duplicates or out of order, but I could be wrong - if so, let me know, and I'll add more test cases.

Thanks,
Rowan
