### PR TITLE
ZoneInfoProvider.getZone(String) throws a ClassCastException in some Android implementations of the String class

### DIFF
--- a/src/main/java/org/joda/time/tz/ZoneInfoProvider.java
+++ b/src/main/java/org/joda/time/tz/ZoneInfoProvider.java
@@ -141,11 +141,6 @@ public class ZoneInfoProvider implements Provider {
             return null;
         }
 
-        if (id.equals(obj)) {
-            // Load zone data for the first time.
-            return loadZoneData(id);
-        }
-
         if (obj instanceof SoftReference<?>) {
             @SuppressWarnings("unchecked")
             SoftReference<DateTimeZone> ref = (SoftReference<DateTimeZone>) obj;
@@ -154,6 +149,9 @@ public class ZoneInfoProvider implements Provider {
                 return tz;
             }
             // Reference cleared; load data again.
+            return loadZoneData(id);
+        } else if (id.equals(obj)) {
+            // Load zone data for the first time.
             return loadZoneData(id);
         }
 


### PR DESCRIPTION
String.equals(SoftReference<?>) throws a ClassCastException in some Android implementations during a LocalDate.now() call:

```
Caused by: java.lang.ClassCastException: java.lang.ref.SoftReference cannot be cast to java.lang.String
at com.hooks.Hooks.java_lang_String_VTequals(Hooks.java:7540)
at org.joda.time.tz.ZoneInfoProvider.getZone(ZoneInfoProvider.java:145)
at org.joda.time.DateTimeZone.setProvider0(DateTimeZone.java:426)
at org.joda.time.DateTimeZone.<clinit>(DateTimeZone.java:116)
... 17 more
```

Reordering the code would check first the instanceof case and only then call the .equals() method with an object of a type that it's not a SoftReference.
