### PR TITLE
Adds Appendable support, uses StringBuilder instead of StringBuffer #120

### DIFF
--- a/src/main/java/org/joda/time/format/DateTimeFormat.java
+++ b/src/main/java/org/joda/time/format/DateTimeFormat.java
@@ -825,6 +825,13 @@ public class DateTimeFormat {
             p.printTo(out, instant, chrono, displayOffset, displayZone, locale);
         }
 
+        public void printTo(
+                Appendable appenadble, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            DateTimePrinter p = getFormatter(locale).getPrinter();
+            p.printTo(appenadble, instant, chrono, displayOffset, displayZone, locale);
+        }
+
         public void printTo(StringBuffer buf, ReadablePartial partial, Locale locale) {
             DateTimePrinter p = getFormatter(locale).getPrinter();
             p.printTo(buf, partial, locale);
@@ -835,6 +842,10 @@ public class DateTimeFormat {
             p.printTo(out, partial, locale);
         }
 
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
+            DateTimePrinter p = getFormatter(locale).getPrinter();
+            p.printTo(appendable, partial, locale);
+        }
         public int estimateParsedLength() {
             return 40;  // guess
         }

--- a/src/main/java/org/joda/time/format/DateTimeFormatterBuilder.java
+++ b/src/main/java/org/joda/time/format/DateTimeFormatterBuilder.java
@@ -1190,6 +1190,12 @@ public class DateTimeFormatterBuilder {
         }
     }
 
+    static void appendUnknownString(Appendable appendable, int len) throws IOException {
+        for (int i = len; --i >= 0;) {
+            appendable.append('\ufffd');
+        }
+    }
+
     static void printUnknownString(Writer out, int len) throws IOException {
         for (int i = len; --i >= 0;) {
             out.write('\ufffd');
@@ -1223,12 +1229,22 @@ public class DateTimeFormatterBuilder {
             out.write(iValue);
         }
 
+        public void printTo(
+                Appendable appendable, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            appendable.append(iValue);
+        }
+
         public void printTo(StringBuffer buf, ReadablePartial partial, Locale locale) {
             buf.append(iValue);
         }
 
         public void printTo(Writer out, ReadablePartial partial, Locale locale) throws IOException {
             out.write(iValue);
+        }
+
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
+            appendable.append(iValue);
         }
 
         public int estimateParsedLength() {
@@ -1286,12 +1302,22 @@ public class DateTimeFormatterBuilder {
             out.write(iValue);
         }
 
+        public void printTo(
+                Appendable appendable, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            appendable.append(iValue);
+        }
+
         public void printTo(StringBuffer buf, ReadablePartial partial, Locale locale) {
             buf.append(iValue);
         }
 
         public void printTo(Writer out, ReadablePartial partial, Locale locale) throws IOException {
             out.write(iValue);
+        }
+
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
+            appendable.append(iValue);
         }
 
         public int estimateParsedLength() {
@@ -1408,10 +1434,9 @@ public class DateTimeFormatterBuilder {
                 StringBuffer buf, long instant, Chronology chrono,
                 int displayOffset, DateTimeZone displayZone, Locale locale) {
             try {
-                DateTimeField field = iFieldType.getField(chrono);
-                FormatUtils.appendUnpaddedInteger(buf, field.get(instant));
-            } catch (RuntimeException e) {
-                buf.append('\ufffd');
+                printTo((Appendable)buf, instant, chrono, displayOffset, displayZone, locale);
+            } catch (IOException e) {
+                // StringBuffer does not throw IOException
             }
         }
 
@@ -1426,15 +1451,22 @@ public class DateTimeFormatterBuilder {
             }
         }
 
+        public void printTo(
+                Appendable appendable, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            try {
+                DateTimeField field = iFieldType.getField(chrono);
+                FormatUtils.appendUnpaddedInteger(appendable, field.get(instant));
+            } catch (RuntimeException e) {
+                appendable.append('\ufffd');
+            }
+        }
+
         public void printTo(StringBuffer buf, ReadablePartial partial, Locale locale) {
-            if (partial.isSupported(iFieldType)) {
-                try {
-                    FormatUtils.appendUnpaddedInteger(buf, partial.get(iFieldType));
-                } catch (RuntimeException e) {
-                    buf.append('\ufffd');
-                }
-            } else {
-                buf.append('\ufffd');
+            try {
+                printTo((Appendable)buf, partial, locale);
+            } catch (IOException e) {
+                // StringBuffer does not throw IOException
             }
         }
 
@@ -1447,6 +1479,18 @@ public class DateTimeFormatterBuilder {
                 }
             } else {
                 out.write('\ufffd');
+            }
+        }
+
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
+            if (partial.isSupported(iFieldType)) {
+                try {
+                    FormatUtils.appendUnpaddedInteger(appendable, partial.get(iFieldType));
+                } catch (RuntimeException e) {
+                    appendable.append('\ufffd');
+                }
+            } else {
+                appendable.append('\ufffd');
             }
         }
     }
@@ -1471,10 +1515,9 @@ public class DateTimeFormatterBuilder {
                 StringBuffer buf, long instant, Chronology chrono,
                 int displayOffset, DateTimeZone displayZone, Locale locale) {
             try {
-                DateTimeField field = iFieldType.getField(chrono);
-                FormatUtils.appendPaddedInteger(buf, field.get(instant), iMinPrintedDigits);
-            } catch (RuntimeException e) {
-                appendUnknownString(buf, iMinPrintedDigits);
+                printTo((Appendable)buf, instant, chrono, displayOffset, displayZone, locale);
+            } catch (IOException e) {
+                // StringBuffer does not throw IOException
             }
         }
 
@@ -1489,15 +1532,22 @@ public class DateTimeFormatterBuilder {
             }
         }
 
+        public void printTo(
+                Appendable appendable, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            try {
+                DateTimeField field = iFieldType.getField(chrono);
+                FormatUtils.appendPaddedInteger(appendable, field.get(instant), iMinPrintedDigits);
+            } catch (RuntimeException e) {
+                appendUnknownString(appendable, iMinPrintedDigits);
+            }
+        }
+
         public void printTo(StringBuffer buf, ReadablePartial partial, Locale locale) {
-            if (partial.isSupported(iFieldType)) {
-                try {
-                    FormatUtils.appendPaddedInteger(buf, partial.get(iFieldType), iMinPrintedDigits);
-                } catch (RuntimeException e) {
-                    appendUnknownString(buf, iMinPrintedDigits);
-                }
-            } else {
-                appendUnknownString(buf, iMinPrintedDigits);
+            try {
+                printTo((Appendable)buf, partial, locale);
+            } catch (IOException e) {
+                // StringBuffer does not throw IOException
             }
         }
 
@@ -1510,6 +1560,18 @@ public class DateTimeFormatterBuilder {
                 }
             } else {
                 printUnknownString(out, iMinPrintedDigits);
+            }
+        }
+
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
+            if (partial.isSupported(iFieldType)) {
+                try {
+                    FormatUtils.appendPaddedInteger(appendable, partial.get(iFieldType), iMinPrintedDigits);
+                } catch (RuntimeException e) {
+                    appendUnknownString(appendable, iMinPrintedDigits);
+                }
+            } else {
+                appendUnknownString(appendable, iMinPrintedDigits);
             }
         }
     }
@@ -1694,6 +1756,18 @@ public class DateTimeFormatterBuilder {
             }
         }
 
+        public void printTo(
+                Appendable appendable, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            int year = getTwoDigitYear(instant, chrono);
+            if (year < 0) {
+                appendable.append('\ufffd');
+                appendable.append('\ufffd');
+            } else {
+                FormatUtils.appendPaddedInteger(appendable, year, 2);
+            }
+        }
+
         private int getTwoDigitYear(long instant, Chronology chrono) {
             try {
                 int year = iType.getField(chrono).get(instant);
@@ -1723,6 +1797,16 @@ public class DateTimeFormatterBuilder {
                 out.write('\ufffd');
             } else {
                 FormatUtils.writePaddedInteger(out, year, 2);
+            }
+        }
+
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
+            int year = getTwoDigitYear(partial);
+            if (year < 0) {
+                appendable.append('\ufffd');
+                appendable.append('\ufffd');
+            } else {
+                FormatUtils.appendPaddedInteger(appendable, year, 2);
             }
         }
 
@@ -1779,6 +1863,16 @@ public class DateTimeFormatterBuilder {
             }
         }
 
+        public void printTo(
+                Appendable appendable, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            try {
+                appendable.append(print(instant, chrono, locale));
+            } catch (RuntimeException e) {
+                appendable.append('\ufffd');
+            }
+        }
+
         public void printTo(StringBuffer buf, ReadablePartial partial, Locale locale) {
             try {
                 buf.append(print(partial, locale));
@@ -1792,6 +1886,14 @@ public class DateTimeFormatterBuilder {
                 out.write(print(partial, locale));
             } catch (RuntimeException e) {
                 out.write('\ufffd');
+            }
+        }
+
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
+            try {
+                appendable.append(print(partial, locale));
+            } catch (RuntimeException e) {
+                appendable.append('\ufffd');
             }
         }
 
@@ -1909,7 +2011,7 @@ public class DateTimeFormatterBuilder {
             try {
                 printTo(buf, null, instant, chrono);
             } catch (IOException e) {
-                // Not gonna happen.
+                // StringBuffer does not throw IOException
             }
         }
 
@@ -1919,6 +2021,12 @@ public class DateTimeFormatterBuilder {
             printTo(null, out, instant, chrono);
         }
 
+        public void printTo(
+                Appendable appendable, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            printTo(appendable, null, instant, chrono);
+        }
+
         public void printTo(StringBuffer buf, ReadablePartial partial, Locale locale) {
             // removed check whether field is supported, as input field is typically
             // secondOfDay which is unsupported by TimeOfDay
@@ -1926,7 +2034,7 @@ public class DateTimeFormatterBuilder {
             try {
                 printTo(buf, null, millis, partial.getChronology());
             } catch (IOException e) {
-                // Not gonna happen.
+                // StringBuffer does not throw IOException
             }
         }
 
@@ -1937,7 +2045,14 @@ public class DateTimeFormatterBuilder {
             printTo(null, out, millis, partial.getChronology());
         }
 
-        protected void printTo(StringBuffer buf, Writer out, long instant, Chronology chrono)
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
+            // removed check whether field is supported, as input field is typically
+            // secondOfDay which is unsupported by TimeOfDay
+            long millis = partial.getChronology().set(partial, 0L);
+            printTo(appendable, null , millis, partial.getChronology());
+        }
+
+        protected void printTo(Appendable appendable, Writer out, long instant, Chronology chrono)
             throws IOException
         {
             DateTimeField field = iFieldType.getField(chrono);
@@ -1947,8 +2062,8 @@ public class DateTimeFormatterBuilder {
             try {
                 fraction = field.remainder(instant);
             } catch (RuntimeException e) {
-                if (buf != null) {
-                    appendUnknownString(buf, minDigits);
+                if (appendable != null) {
+                    appendUnknownString(appendable, minDigits);
                 } else {
                     printUnknownString(out, minDigits);
                 }
@@ -1956,9 +2071,9 @@ public class DateTimeFormatterBuilder {
             }
 
             if (fraction == 0) {
-                if (buf != null) {
+                if (appendable != null) {
                     while (--minDigits >= 0) {
-                        buf.append('0');
+                        appendable.append('0');
                     }
                 } else {
                     while (--minDigits >= 0) {
@@ -1982,8 +2097,8 @@ public class DateTimeFormatterBuilder {
             int length = str.length();
             int digits = maxDigits;
             while (length < digits) {
-                if (buf != null) {
-                    buf.append('0');
+                if (appendable != null) {
+                    appendable.append('0');
                 } else {
                     out.write('0');
                 }
@@ -2001,9 +2116,9 @@ public class DateTimeFormatterBuilder {
                     length--;
                 }
                 if (length < str.length()) {
-                    if (buf != null) {
+                    if (appendable != null) {
                         for (int i=0; i<length; i++) {
-                            buf.append(str.charAt(i));
+                            appendable.append(str.charAt(i));
                         }
                     } else {
                         for (int i=0; i<length; i++) {
@@ -2014,8 +2129,8 @@ public class DateTimeFormatterBuilder {
                 }
             }
 
-            if (buf != null) {
-                buf.append(str);
+            if (appendable != null) {
+                appendable.append(str);
             } else {
                 out.write(str);
             }
@@ -2140,66 +2255,17 @@ public class DateTimeFormatterBuilder {
             }
             return est;
         }
-        
+
         public void printTo(
                 StringBuffer buf, long instant, Chronology chrono,
                 int displayOffset, DateTimeZone displayZone, Locale locale) {
-            if (displayZone == null) {
-                return;  // no zone
+            try {
+                printTo((Appendable) buf, instant, chrono, displayOffset, displayZone, locale);
+            } catch (IOException e) {
+                // StringBuffer does not throw IOException
             }
-            if (displayOffset == 0 && iZeroOffsetPrintText != null) {
-                buf.append(iZeroOffsetPrintText);
-                return;
-            }
-            if (displayOffset >= 0) {
-                buf.append('+');
-            } else {
-                buf.append('-');
-                displayOffset = -displayOffset;
-            }
-
-            int hours = displayOffset / DateTimeConstants.MILLIS_PER_HOUR;
-            FormatUtils.appendPaddedInteger(buf, hours, 2);
-            if (iMaxFields == 1) {
-                return;
-            }
-            displayOffset -= hours * (int)DateTimeConstants.MILLIS_PER_HOUR;
-            if (displayOffset == 0 && iMinFields <= 1) {
-                return;
-            }
-
-            int minutes = displayOffset / DateTimeConstants.MILLIS_PER_MINUTE;
-            if (iShowSeparators) {
-                buf.append(':');
-            }
-            FormatUtils.appendPaddedInteger(buf, minutes, 2);
-            if (iMaxFields == 2) {
-                return;
-            }
-            displayOffset -= minutes * DateTimeConstants.MILLIS_PER_MINUTE;
-            if (displayOffset == 0 && iMinFields <= 2) {
-                return;
-            }
-
-            int seconds = displayOffset / DateTimeConstants.MILLIS_PER_SECOND;
-            if (iShowSeparators) {
-                buf.append(':');
-            }
-            FormatUtils.appendPaddedInteger(buf, seconds, 2);
-            if (iMaxFields == 3) {
-                return;
-            }
-            displayOffset -= seconds * DateTimeConstants.MILLIS_PER_SECOND;
-            if (displayOffset == 0 && iMinFields <= 3) {
-                return;
-            }
-
-            if (iShowSeparators) {
-                buf.append('.');
-            }
-            FormatUtils.appendPaddedInteger(buf, displayOffset, 3);
         }
-        
+
         public void printTo(
                 Writer out, long instant, Chronology chrono,
                 int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
@@ -2259,11 +2325,74 @@ public class DateTimeFormatterBuilder {
             FormatUtils.writePaddedInteger(out, displayOffset, 3);
         }
 
+        public void printTo(
+                Appendable buf, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            if (displayZone == null) {
+                return;  // no zone
+            }
+            if (displayOffset == 0 && iZeroOffsetPrintText != null) {
+                buf.append(iZeroOffsetPrintText);
+                return;
+            }
+            if (displayOffset >= 0) {
+                buf.append('+');
+            } else {
+                buf.append('-');
+                displayOffset = -displayOffset;
+            }
+
+            int hours = displayOffset / DateTimeConstants.MILLIS_PER_HOUR;
+            FormatUtils.appendPaddedInteger(buf, hours, 2);
+            if (iMaxFields == 1) {
+                return;
+            }
+            displayOffset -= hours * (int)DateTimeConstants.MILLIS_PER_HOUR;
+            if (displayOffset == 0 && iMinFields <= 1) {
+                return;
+            }
+
+            int minutes = displayOffset / DateTimeConstants.MILLIS_PER_MINUTE;
+            if (iShowSeparators) {
+                buf.append(':');
+            }
+            FormatUtils.appendPaddedInteger(buf, minutes, 2);
+            if (iMaxFields == 2) {
+                return;
+            }
+            displayOffset -= minutes * DateTimeConstants.MILLIS_PER_MINUTE;
+            if (displayOffset == 0 && iMinFields <= 2) {
+                return;
+            }
+
+            int seconds = displayOffset / DateTimeConstants.MILLIS_PER_SECOND;
+            if (iShowSeparators) {
+                buf.append(':');
+            }
+            FormatUtils.appendPaddedInteger(buf, seconds, 2);
+            if (iMaxFields == 3) {
+                return;
+            }
+            displayOffset -= seconds * DateTimeConstants.MILLIS_PER_SECOND;
+            if (displayOffset == 0 && iMinFields <= 3) {
+                return;
+            }
+
+            if (iShowSeparators) {
+                buf.append('.');
+            }
+            FormatUtils.appendPaddedInteger(buf, displayOffset, 3);
+        }
+
         public void printTo(StringBuffer buf, ReadablePartial partial, Locale locale) {
             // no zone info
         }
 
         public void printTo(Writer out, ReadablePartial partial, Locale locale) throws IOException {
+            // no zone info
+        }
+
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
             // no zone info
         }
 
@@ -2492,6 +2621,12 @@ public class DateTimeFormatterBuilder {
             out.write(print(instant - displayOffset, displayZone, locale));
         }
 
+        public void printTo(
+                Appendable appendable, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            appendable.append(print(instant - displayOffset, displayZone, locale));
+        }
+
         private String print(long instant, DateTimeZone displayZone, Locale locale) {
             if (displayZone == null) {
                 return "";  // no zone
@@ -2510,6 +2645,10 @@ public class DateTimeFormatterBuilder {
         }
 
         public void printTo(Writer out, ReadablePartial partial, Locale locale) throws IOException {
+            // no zone info
+        }
+
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
             // no zone info
         }
 
@@ -2568,11 +2707,21 @@ public class DateTimeFormatterBuilder {
             out.write(displayZone != null ? displayZone.getID() : "");
         }
 
+        public void printTo(
+                Appendable appendable, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            appendable.append(displayZone != null ? displayZone.getID() : "");
+        }
+
         public void printTo(StringBuffer buf, ReadablePartial partial, Locale locale) {
             // no zone info
         }
 
         public void printTo(Writer out, ReadablePartial partial, Locale locale) throws IOException {
+            // no zone info
+        }
+
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
             // no zone info
         }
 
@@ -2689,6 +2838,25 @@ public class DateTimeFormatterBuilder {
             }
         }
 
+        public void printTo(
+                Appendable appendable, long instant, Chronology chrono,
+                int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException {
+            DateTimePrinter[] elements = iPrinters;
+            if (elements == null) {
+                throw new UnsupportedOperationException();
+            }
+
+            if (locale == null) {
+                // Guard against default locale changing concurrently.
+                locale = Locale.getDefault();
+            }
+
+            int len = elements.length;
+            for (int i = 0; i < len; i++) {
+                elements[i].printTo(appendable, instant, chrono, displayOffset, displayZone, locale);
+            }
+        }
+
         public void printTo(StringBuffer buf, ReadablePartial partial, Locale locale) {
             DateTimePrinter[] elements = iPrinters;
             if (elements == null) {
@@ -2720,6 +2888,23 @@ public class DateTimeFormatterBuilder {
             int len = elements.length;
             for (int i=0; i<len; i++) {
                 elements[i].printTo(out, partial, locale);
+            }
+        }
+
+        public void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException {
+            DateTimePrinter[] elements = iPrinters;
+            if (elements == null) {
+                throw new UnsupportedOperationException();
+            }
+
+            if (locale == null) {
+                // Guard against default locale changing concurrently.
+                locale = Locale.getDefault();
+            }
+
+            int len = elements.length;
+            for (int i=0; i<len; i++) {
+                elements[i].printTo(appendable, partial, locale);
             }
         }
 

--- a/src/main/java/org/joda/time/format/DateTimePrinter.java
+++ b/src/main/java/org/joda/time/format/DateTimePrinter.java
@@ -71,7 +71,7 @@ public interface DateTimePrinter {
      * Prints an instant from milliseconds since 1970-01-01T00:00:00Z,
      * using the given Chronology.
      *
-     * @param out  formatted instant is written out
+     * @param out  formatted instant is written out, not null
      * @param instant  millis since 1970-01-01T00:00:00Z
      * @param chrono  the chronology to use, not null
      * @param displayOffset  if a time zone offset is printed, force it to use
@@ -82,6 +82,21 @@ public interface DateTimePrinter {
     void printTo(Writer out, long instant, Chronology chrono,
                  int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException;
 
+    /**
+     * Prints an instant from milliseconds since 1970-01-01T00:00:00Z,
+     * using the given Chronology.
+     *
+     * @param appendable  formatted instant is appended to, not null
+     * @param instant  millis since 1970-01-01T00:00:00Z
+     * @param chrono  the chronology to use, not null
+     * @param displayOffset  if a time zone offset is printed, force it to use
+     * this millisecond value
+     * @param displayZone  the time zone to use, null means local time
+     * @param locale  the locale to use, null means default locale
+      * @since 2.4
+     */
+    void printTo(Appendable appendable, long instant, Chronology chrono,
+                 int displayOffset, DateTimeZone displayZone, Locale locale) throws IOException;
     //-----------------------------------------------------------------------
     /**
      * Prints a ReadablePartial.
@@ -100,5 +115,15 @@ public interface DateTimePrinter {
      * @param locale  the locale to use, null means default locale
      */
     void printTo(Writer out, ReadablePartial partial, Locale locale) throws IOException;
+
+    /**
+     * Prints a ReadablePartial.
+     *
+     * @param appendable  formatted instant is appended to, not null
+     * @param partial  partial to format, not null
+     * @param locale  the locale to use, null means default locale
+     * @since 2.4
+     */
+    void printTo(Appendable appendable, ReadablePartial partial, Locale locale) throws IOException;
 
 }

--- a/src/main/java/org/joda/time/format/FormatUtils.java
+++ b/src/main/java/org/joda/time/format/FormatUtils.java
@@ -44,37 +44,56 @@ public class FormatUtils {
      *
      * @param buf receives integer converted to a string
      * @param value value to convert to a string
-     * @param size minumum amount of digits to append
+     * @param size minimum amount of digits to append
      */
     public static void appendPaddedInteger(StringBuffer buf, int value, int size) {
+        try {
+            appendPaddedInteger((Appendable)buf, value, size);
+        } catch (IOException e) {
+            // StringBuffer does not throw IOException
+        }
+    }
+
+    /**
+     * Converts an integer to a string, prepended with a variable amount of '0'
+     * pad characters, and appends it to the given appendable.
+     *
+     * <p>This method is optimized for converting small values to strings.
+     *
+     * @param appenadble receives integer converted to a string
+     * @param value value to convert to a string
+     * @param size minimum amount of digits to append
+     * @since 2.4
+     */
+    public static void appendPaddedInteger(Appendable appenadble, int value, int size) throws IOException {
         if (value < 0) {
-            buf.append('-');
+            appenadble.append('-');
             if (value != Integer.MIN_VALUE) {
                 value = -value;
             } else {
                 for (; size > 10; size--) {
-                    buf.append('0');
+                    appenadble.append('0');
                 }
-                buf.append("" + -(long)Integer.MIN_VALUE);
+                appenadble.append("" + -(long)Integer.MIN_VALUE);
                 return;
             }
         }
         if (value < 10) {
             for (; size > 1; size--) {
-                buf.append('0');
+                appenadble.append('0');
             }
-            buf.append((char)(value + '0'));
+            appenadble.append((char)(value + '0'));
         } else if (value < 100) {
             for (; size > 2; size--) {
-                buf.append('0');
+                appenadble.append('0');
             }
             // Calculate value div/mod by 10 without using two expensive
             // division operations. (2 ^ 27) / 10 = 13421772. Add one to
             // value to correct rounding error.
             int d = ((value + 1) * 13421772) >> 27;
-            buf.append((char) (d + '0'));
+            appenadble.append((char) (d + '0'));
             // Append remainder by calculating (value - d * 10).
-            buf.append((char) (value - (d << 3) - (d << 1) + '0'));
+            appenadble.append((char) (value - (d << 3) - (d << 1) + '0'));
         } else {
             int digits;
             if (value < 1000) {
@@ -85,9 +104,27 @@ public class FormatUtils {
                 digits = (int)(Math.log(value) / LOG_10) + 1;
             }
             for (; size > digits; size--) {
-                buf.append('0');
+                appenadble.append('0');
             }
-            buf.append(Integer.toString(value));
+            appenadble.append(Integer.toString(value));
+        }
+    }
+    
+    /**
+     * Converts an integer to a string, prepended with a variable amount of '0'
+     * pad characters, and appends it to the given buffer.
+     *
+     * <p>This method is optimized for converting small values to strings.
+     *
+     * @param buf receives integer converted to a string
+     * @param value value to convert to a string
+     * @param size minimum amount of digits to append
+     */
+    public static void appendPaddedInteger(StringBuffer buf, long value, int size) {
+        try {
+            appendPaddedInteger((Appendable)buf, value, size);
+        } catch (IOException e) {
+            // StringBuffer does not throw IOException
         }
     }
 
@@ -97,34 +134,35 @@ public class FormatUtils {
      *
      * <p>This method is optimized for converting small values to strings.
      *
-     * @param buf receives integer converted to a string
+     * @param appendable receives integer converted to a string
      * @param value value to convert to a string
-     * @param size minumum amount of digits to append
+     * @param size minimum amount of digits to append
+     * @since 2.4
      */
-    public static void appendPaddedInteger(StringBuffer buf, long value, int size) {
+    public static void appendPaddedInteger(Appendable appendable, long value, int size) throws IOException {
         int intValue = (int)value;
         if (intValue == value) {
-            appendPaddedInteger(buf, intValue, size);
+            appendPaddedInteger(appendable, intValue, size);
         } else if (size <= 19) {
-            buf.append(Long.toString(value));
+            appendable.append(Long.toString(value));
         } else {
             if (value < 0) {
-                buf.append('-');
+                appendable.append('-');
                 if (value != Long.MIN_VALUE) {
                     value = -value;
                 } else {
                     for (; size > 19; size--) {
-                        buf.append('0');
+                        appendable.append('0');
                     }
-                    buf.append("9223372036854775808");
+                    appendable.append("9223372036854775808");
                     return;
                 }
             }
             int digits = (int)(Math.log(value) / LOG_10) + 1;
             for (; size > digits; size--) {
-                buf.append('0');
+                appendable.append('0');
             }
-            buf.append(Long.toString(value));
+            appendable.append(Long.toString(value));
         }
     }
 
@@ -136,7 +174,7 @@ public class FormatUtils {
      *
      * @param out receives integer converted to a string
      * @param value value to convert to a string
-     * @param size minumum amount of digits to append
+     * @param size minimum amount of digits to append
      */
     public static void writePaddedInteger(Writer out, int value, int size)
         throws IOException
@@ -193,7 +231,7 @@ public class FormatUtils {
      *
      * @param out receives integer converted to a string
      * @param value value to convert to a string
-     * @param size minumum amount of digits to append
+     * @param size minimum amount of digits to append
      */
     public static void writePaddedInteger(Writer out, long value, int size)
         throws IOException
@@ -233,27 +271,44 @@ public class FormatUtils {
      * @param value value to convert to a string
      */
     public static void appendUnpaddedInteger(StringBuffer buf, int value) {
+        try {
+            appendUnpaddedInteger((Appendable) buf, value);
+        } catch (IOException e) {
+            // StringBuffer do not throw IOException
+        }
+    }
+
+    /**
+     * Converts an integer to a string, and appends it to the given appendable.
+     *
+     * <p>This method is optimized for converting small values to strings.
+     *
+     * @param appendable receives integer converted to a string
+     * @param value value to convert to a string
+     * @since 2.4
+     */
+    public static void appendUnpaddedInteger(Appendable appendable, int value) throws IOException {
         if (value < 0) {
-            buf.append('-');
+            appendable.append('-');
             if (value != Integer.MIN_VALUE) {
                 value = -value;
             } else {
-                buf.append("" + -(long)Integer.MIN_VALUE);
+                appendable.append("" + -(long)Integer.MIN_VALUE);
                 return;
             }
         }
         if (value < 10) {
-            buf.append((char)(value + '0'));
+            appendable.append((char)(value + '0'));
         } else if (value < 100) {
             // Calculate value div/mod by 10 without using two expensive
             // division operations. (2 ^ 27) / 10 = 13421772. Add one to
             // value to correct rounding error.
             int d = ((value + 1) * 13421772) >> 27;
-            buf.append((char) (d + '0'));
+            appendable.append((char) (d + '0'));
             // Append remainder by calculating (value - d * 10).
-            buf.append((char) (value - (d << 3) - (d << 1) + '0'));
+            appendable.append((char) (value - (d << 3) - (d << 1) + '0'));
         } else {
-            buf.append(Integer.toString(value));
+            appendable.append(Integer.toString(value));
         }
     }
 
@@ -266,11 +321,27 @@ public class FormatUtils {
      * @param value value to convert to a string
      */
     public static void appendUnpaddedInteger(StringBuffer buf, long value) {
+        try {
+            appendUnpaddedInteger((Appendable) buf, value);
+        } catch (IOException e) {
+            // StringBuffer do not throw IOException
+        }
+    }
+
+    /**
+     * Converts an integer to a string, and appends it to the given appendable.
+     *
+     * <p>This method is optimized for converting small values to strings.
+     *
+     * @param appendable receives integer converted to a string
+     * @param value value to convert to a string
+     */
+    public static void appendUnpaddedInteger(Appendable appendable, long value) throws IOException {
         int intValue = (int)value;
         if (intValue == value) {
-            appendUnpaddedInteger(buf, intValue);
+            appendUnpaddedInteger(appendable, intValue);
         } else {
-            buf.append(Long.toString(value));
+            appendable.append(Long.toString(value));
         }
     }
 


### PR DESCRIPTION
This Pull Request adds additional Appendable supporting methods to DateTimeFormat and DateTimePrinter. It also switches the internal usage from StringBuffer to StringBuilder.
I followed the existing pattern by c&p ing short methdos. Other delegate the call and suppress the IOException.
It also fixes minor javadoc typos.
