### PR TITLE
Added a comment to DateTime.java regarding the incompatibility of DateTime.parse(str) and DateTime(str)

### DIFF
--- a/src/main/java/org/joda/time/DateTime.java
+++ b/src/main/java/org/joda/time/DateTime.java
@@ -123,7 +123,12 @@ public final class DateTime
     /**
      * Parses a {@code DateTime} from the specified string.
      * <p>
-     * This uses {@link ISODateTimeFormat#dateTimeParser()}.
+     * This uses {@link ISODateTimeFormat#dateTimeParser().withOffsetParsed()}.
+     * <p>
+     * Note that {@code DateTime.parse(str).equals(new
+     * DateTime(str)) == false} because the associated chronologies are
+     * not equal: The former has a FixedDateTimeZone and the latter has a
+     * CachedDateTimeZone.
      * 
      * @param str  the string to parse, not null
      * @since 2.0


### PR DESCRIPTION
Added a comment to DateTime.java regarding the incompatibility of
DateTime.parse(String str) and DateTime(String str). Cf.,
https://github.com/JodaOrg/joda-time/issues/106
