### PR TITLE
Don't advance to dayOfWeek if it is 0

### DIFF
--- a/src/main/java/org/joda/time/tz/ZoneInfoCompiler.java
+++ b/src/main/java/org/joda/time/tz/ZoneInfoCompiler.java
@@ -584,10 +584,12 @@ public class ZoneInfoCompiler {
                             LocalDate date = (day == -1 ?
                                     new LocalDate(2001, month, 1).plusMonths(1) :
                                     new LocalDate(2001, month, day).plusDays(1));
-                            advance = (day != -1);
+                            advance = (day != -1 && dayOfWeek != 0);
                             month = date.getMonthOfYear();
                             day = date.getDayOfMonth();
-                            dayOfWeek = ((dayOfWeek - 1 + 1) % 7) + 1;
+                            if (dayOfWeek != 0) {
+                                dayOfWeek = ((dayOfWeek - 1 + 1) % 7) + 1;
+                            }
                         } else {
                             millis = parseTime(str);
                         }

--- a/src/test/java/org/joda/time/tz/TestCompiler.java
+++ b/src/test/java/org/joda/time/tz/TestCompiler.java
@@ -193,6 +193,16 @@ public class TestCompiler extends TestCase {
         assertEquals(false, test.iAdvanceDayOfWeek);
     }
 
+    public void test_2400_specific_day() {
+        StringTokenizer st = new StringTokenizer("Sep 21 24:00");
+        DateTimeOfYear test = new DateTimeOfYear(st);
+        assertEquals(9, test.iMonthOfYear);  // Sep
+        assertEquals(22, test.iDayOfMonth);   // 22st
+        assertEquals(0, test.iDayOfWeek);    // Ignored
+        assertEquals(0, test.iMillisOfDay);  // 00:00
+        assertEquals(false, test.iAdvanceDayOfWeek);
+    }
+
     public void test_Amman_2003() {
         DateTimeZone zone = DateTimeZone.forID("Asia/Amman");
         DateTime dt = new DateTime(2003, 3, 1, 0, 0, zone);


### PR DESCRIPTION
If 24:00 is used with a specific day, it will advance to next Monday, since advance is set to true and dayOfWeek is updated to 1.

To fix #173:
1, don't set advance to true if dayOfWeek is 0.
2, don't update dayOfWeek if it is 0.
