### PR TITLE
#187 Deprecate PeriodFormatter#withLocale. Set correct locale for Period...

### DIFF
--- a/src/main/java/org/joda/time/format/PeriodFormat.java
+++ b/src/main/java/org/joda/time/format/PeriodFormat.java
@@ -199,16 +199,16 @@ public class PeriodFormat {
         if (pf == null) {
             ResourceBundle b = ResourceBundle.getBundle(BUNDLE_NAME, locale);
             if (containsKey(b, "PeriodFormat.regex.separator")) {
-                pf = buildRegExFormatter(b);
+                pf = buildRegExFormatter(b, locale);
             } else {
-                pf = buildNonRegExFormatter(b);
+                pf = buildNonRegExFormatter(b, locale);
             }
             FORMATTERS.putIfAbsent(locale, pf);
         }
         return pf;
     }
 
-    private static PeriodFormatter buildRegExFormatter(ResourceBundle b) {
+    private static PeriodFormatter buildRegExFormatter(ResourceBundle b, Locale locale) {
         String[] variants = retrieveVariants(b);
         String regExSeparator = b.getString("PeriodFormat.regex.separator");
         
@@ -291,10 +291,11 @@ public class PeriodFormat {
         } else {
             builder.appendSuffix(b.getString("PeriodFormat.millisecond"), b.getString("PeriodFormat.milliseconds"));
         }
+        builder.withLocale(locale);
         return builder.toFormatter();
     }
 
-    private static PeriodFormatter buildNonRegExFormatter(ResourceBundle b) {
+    private static PeriodFormatter buildNonRegExFormatter(ResourceBundle b, Locale locale) {
         String[] variants = retrieveVariants(b);
         return new PeriodFormatterBuilder()
             .appendYears()
@@ -320,6 +321,7 @@ public class PeriodFormat {
             .appendSeparator(b.getString("PeriodFormat.commaspace"), b.getString("PeriodFormat.spaceandspace"), variants)
             .appendMillis()
             .appendSuffix(b.getString("PeriodFormat.millisecond"), b.getString("PeriodFormat.milliseconds"))
+            .withLocale(locale)
             .toFormatter();
     }
 

--- a/src/main/java/org/joda/time/format/PeriodFormatter.java
+++ b/src/main/java/org/joda/time/format/PeriodFormatter.java
@@ -99,7 +99,7 @@ public class PeriodFormatter {
      * @param locale  the locale to use
      * @param type  the parse period type
      */
-    private PeriodFormatter(
+    PeriodFormatter(
             PeriodPrinter printer, PeriodParser parser,
             Locale locale, PeriodType type) {
         super();
@@ -148,15 +148,20 @@ public class PeriodFormatter {
 
     //-----------------------------------------------------------------------
     /**
-     * Returns a new formatter with a different locale that will be used
-     * for printing and parsing.
+     * Returns a new formatter with a different locale.
+     * Note that the returned PeriodFormatter will work exactly the same as this instance
+     * with the exception of {@link org.joda.time.format.PeriodFormatter#getLocale()} method
+     * which will return the passed locale. The passed locale will have no effect
+     * on the localization of prefixes/suffixes done with the help of the returned PeriodFormatter.
      * <p>
      * A PeriodFormatter is immutable, so a new instance is returned,
      * and the original is unaltered and still usable.
-     * 
+     *
      * @param locale  the locale to use
      * @return the new formatter
+     * @deprecated use {@link PeriodFormat#wordBased(java.util.Locale)} to create a new PeriodFormatter
      */
+    @Deprecated
     public PeriodFormatter withLocale(Locale locale) {
         if (locale == getLocale() || (locale != null && locale.equals(getLocale()))) {
             return this;

--- a/src/main/java/org/joda/time/format/PeriodFormatterBuilder.java
+++ b/src/main/java/org/joda/time/format/PeriodFormatterBuilder.java
@@ -97,6 +97,8 @@ public class PeriodFormatterBuilder {
 
     private PeriodFieldAffix iPrefix;
 
+    private Locale locale;
+
     // List of Printers and Parsers used to build a final formatter.
     private List<Object> iElementPairs;
     /** Set to true if the formatter is not a printer. */
@@ -129,7 +131,7 @@ public class PeriodFormatterBuilder {
      * @throws IllegalStateException if the builder can produce neither a printer nor a parser
      */
     public PeriodFormatter toFormatter() {
-        PeriodFormatter formatter = toFormatter(iElementPairs, iNotPrinter, iNotParser);
+        PeriodFormatter formatter = toFormatter(iElementPairs, iNotPrinter, iNotParser, locale);
         for (FieldFormatter fieldFormatter : iFieldFormatters) {
             if (fieldFormatter != null) {
                 fieldFormatter.finish(iFieldFormatters);
@@ -195,6 +197,19 @@ public class PeriodFormatterBuilder {
         iNotPrinter = false;
         iNotParser = false;
         iFieldFormatters = new FieldFormatter[10];
+    }
+
+    /**
+     * Sets the locale. This method only sets the locale for reference purposes.
+     * The passed locale does not have effect on the localization of formatted strings
+     * nor parsing of localized strings.
+     *
+     * @param locale  locale describing the PeriodFormatter
+     * @return this PeriodFormatterBuilder
+     */
+    public PeriodFormatterBuilder withLocale(Locale locale) {
+        this.locale = locale;
+        return this;
     }
 
     /**
@@ -887,7 +902,7 @@ public class PeriodFormatterBuilder {
     }
 
     //-----------------------------------------------------------------------
-    private static PeriodFormatter toFormatter(List<Object> elementPairs, boolean notPrinter, boolean notParser) {
+    private static PeriodFormatter toFormatter(List<Object> elementPairs, boolean notPrinter, boolean notParser, Locale locale) {
         if (notPrinter && notParser) {
             throw new IllegalStateException("Builder has created neither a printer nor a parser");
         }
@@ -895,18 +910,18 @@ public class PeriodFormatterBuilder {
         if (size >= 2 && elementPairs.get(0) instanceof Separator) {
             Separator sep = (Separator) elementPairs.get(0);
             if (sep.iAfterParser == null && sep.iAfterPrinter == null) {
-                PeriodFormatter f = toFormatter(elementPairs.subList(2, size), notPrinter, notParser);
+                PeriodFormatter f = toFormatter(elementPairs.subList(2, size), notPrinter, notParser, locale);
                 sep = sep.finish(f.getPrinter(), f.getParser());
-                return new PeriodFormatter(sep, sep);
+                return new PeriodFormatter(sep, sep, locale, null);
             }
         }
         Object[] comp = createComposite(elementPairs);
         if (notPrinter) {
-            return new PeriodFormatter(null, (PeriodParser) comp[1]);
+            return new PeriodFormatter(null, (PeriodParser) comp[1], locale, null);
         } else if (notParser) {
-            return new PeriodFormatter((PeriodPrinter) comp[0], null);
+            return new PeriodFormatter((PeriodPrinter) comp[0], null, locale, null);
         } else {
-            return new PeriodFormatter((PeriodPrinter) comp[0], (PeriodParser) comp[1]);
+            return new PeriodFormatter((PeriodPrinter) comp[0], (PeriodParser) comp[1], locale, null);
         }
     }
 

--- a/src/test/java/org/joda/time/format/TestPeriodFormat.java
+++ b/src/test/java/org/joda/time/format/TestPeriodFormat.java
@@ -609,4 +609,19 @@ public class TestPeriodFormat extends TestCase {
         Period p = new Period(0, 0, 0, 1, 5, 6, 7, 8);
         assertEquals("1 dzie\u0144, 5 godzin, 6 minut, 7 sekund i 8 milisekund", PeriodFormat.wordBased(PL).print(p));
     }
+
+    public void test_getDefault_localeValue() {
+        PeriodFormatter pf = PeriodFormat.getDefault();
+        assertEquals(Locale.ENGLISH, pf.getLocale());
+    }
+
+    public void test_wordBased_localeValue() {
+        PeriodFormatter pf = PeriodFormat.wordBased();
+        assertEquals(DE, pf.getLocale());
+    }
+
+    public void test_wordBasedWithLocale_localeValue() {
+        PeriodFormatter pf = PeriodFormat.wordBased(FR);
+        assertEquals(FR, pf.getLocale());
+    }
 }

--- a/src/test/java/org/joda/time/format/TestPeriodFormatterBuilder.java
+++ b/src/test/java/org/joda/time/format/TestPeriodFormatterBuilder.java
@@ -1135,4 +1135,10 @@ public class TestPeriodFormatterBuilder extends TestCase {
         pfmt2.parsePeriod("PT1003199059S");
     }
 
+    public void testWithLocale() {
+        PeriodFormatter pf1 = builder.withLocale(Locale.ENGLISH).toFormatter();
+        assertEquals(Locale.ENGLISH, pf1.getLocale());
+        PeriodFormatter pf2 = builder.withLocale(Locale.CANADA_FRENCH).toFormatter();
+        assertEquals(Locale.CANADA_FRENCH, pf2.getLocale());
+    }
 }


### PR DESCRIPTION
...Formatter instances created with help of PeriodFormat class.

Addresses issue #187 

It is not something that can be fixed. In my opinion this method should not be there. I suppose it was added during early design.
The value of locale is never used internally (it is passed around, only meaningful usage is the getter - but unless the locale is set with withLocale method it the getter will return null). The PeriodFormat and the PeriodFormatterBuilder never returns a PeriodFormatter with locale different than null.

As to why it is rather not possible to make this method work as one would expect:
The PeriodFormatter contains all of the localized strings required for the it to work. It is does NOT use the stored locale value to pick localized strings during printing/parsing.
PeriodFormatter not only defines the locale but the order of displaying each of the values, prefixes, suffixes etc. One can define a PeriodFormatter so that the year suffix will be 'qwerty' and the month suffix will be 'wsad' and the separator between them will be 'backspace' (you get the picture). I the case like that what kind of PeriodFormatter should be returned from call to withLocale(Locale.CANADA_FRENCH) - I do not know what is the French word for 'backspace', neither does PeriodFormatter class. :-)

We could return a wordBased PeriodFormatter, but I think it is a bad idea - the returned PeriodFormatter would have nothing from the PeriodFormatter instance that the withLocale() was called upon.

I think we should:
 * mark this method as deprecated,
 * warn that this method does not return a PeriodFormatter that behaves differently than the first one,
 * update the PeriodFormat class to produce PeriodFormatter instances with locale different that null.

This pull request does that.