### PR TITLE
Correct treatment of suffix case in PeriodFormatterBuilder reported in #194

### DIFF
--- a/src/main/java/org/joda/time/format/PeriodFormatterBuilder.java
+++ b/src/main/java/org/joda/time/format/PeriodFormatterBuilder.java
@@ -1059,7 +1059,7 @@ public class PeriodFormatterBuilder {
             int sourceLength = periodStr.length();
             search:
             for (int pos = position; pos < sourceLength; pos++) {
-                if (periodStr.regionMatches(true, pos, text, 0, textLength)) {
+                if (periodStr.regionMatches(false, pos, text, 0, textLength)) {
                     if (!matchesOtherAffix(textLength, periodStr, pos)) {
                         return pos;
                     }

--- a/src/test/java/org/joda/time/format/TestPeriodFormatterBuilder.java
+++ b/src/test/java/org/joda/time/format/TestPeriodFormatterBuilder.java
@@ -1135,4 +1135,24 @@ public class TestPeriodFormatterBuilder extends TestCase {
         pfmt2.parsePeriod("PT1003199059S");
     }
 
+    public void testMonthsAndMinutesAreConsideredSeparateAndCaseIsNotIgnored() {
+        PeriodFormatter formatter = builder
+                .appendYears().appendSuffix("Y").appendSeparator(" ")
+                .appendMonths().appendSuffix("M").appendSeparator(" ")
+                .appendWeeks().appendSuffix("W").appendSeparator(" ")
+                .appendDays().appendSuffix("D").appendSeparator(" ")
+                .appendHours().appendSuffix("h").appendSeparator(" ")
+                .appendMinutes().appendSuffix("m").appendSeparator(" ")
+                .appendSeconds().appendSuffix("s")
+                .toFormatter();
+
+        String oneMonth = Period.months(1).toString(formatter);
+        assertEquals("1M", oneMonth);
+        Period period = formatter.parsePeriod(oneMonth);
+        assertEquals(Period.months(1), period);
+        String oneMinute = Period.minutes(1).toString(formatter);
+        assertEquals("1m", oneMinute);
+        period = formatter.parsePeriod(oneMinute);
+        assertEquals(Period.minutes(1), period);
+    }
 }


### PR DESCRIPTION
Formatter previously ignored case sensitivity when working with M and m, for months and minutes, leading to an incorrect result. Aims to resolve issue #194
