### PR TITLE
Revert rule for Asia/Dhaka

### DIFF
--- a/src/main/java/org/joda/time/tz/src/asia
+++ b/src/main/java/org/joda/time/tz/src/asia
@@ -224,7 +224,7 @@ Zone	Asia/Bahrain	3:22:20 -	LMT	1920     # Manamah
 
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
 Rule	Dhaka	2009	only	-	Jun	19	23:00	1:00	S
-Rule	Dhaka	2009	only	-	Dec	31	24:00	0	-
+Rule	Dhaka	2009	only	-	Dec	31	23:59	0	-
 
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Dhaka	6:01:40 -	LMT	1890


### PR DESCRIPTION
The rule was changed with time-zone data 2014h which introduced a bug in the DST calculation.
See #208 
