### PR TITLE
Fixed tz database for Asia/Dhaka

### DIFF
--- a/src/main/java/org/joda/time/tz/src/asia
+++ b/src/main/java/org/joda/time/tz/src/asia
@@ -233,8 +233,8 @@ Zone	Asia/Dhaka	6:01:40 -	LMT	1890
 			5:30	-	IST	1942 Sep
 			6:30	-	BURT	1951 Sep 30
 			6:00	-	DACT	1971 Mar 26 # Dacca Time
-			6:00	-	BDT	2009
-			6:00	Dhaka	BD%sT
+			5:00	Dhaka	BD%sT   2009
+			6:00	-	BDT
 
 # Bhutan
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]


### PR DESCRIPTION
Fixed tz database for Asia/Dhaka

BDST was valid only on 2009.