### PR TITLE
Update MonthDay.plusDays docs

### DIFF
--- a/src/main/java/org/joda/time/MonthDay.java
+++ b/src/main/java/org/joda/time/MonthDay.java
@@ -598,6 +598,9 @@ public final class MonthDay
      * This month-day instance is immutable and unaffected by this method call.
      * The month will wrap at the end of the year from December to January.
      * <p>
+     * If the number of days added requires wrapping past the end of February,
+     * the wrapping will be calculated assuming February has 29 days. 
+     * <p>
      * The following three lines are identical in effect:
      * <pre>
      * MonthDay added = md.plusDays(6);


### PR DESCRIPTION
Updated MonthDay.plusDays Javadoc comment to mention that February is
assumed to have 29 days for calculations that require wrapping past the
end of February. Note that the Javadoc for MonthDay in the new Java 8
date API calls out this limitation as well, and explicitly chose not to
support arithmetic on MonthDays for this reason:
http://docs.oracle.com/javase/8/docs/api/java/time/MonthDay.html