### PR TITLE
PeriodFormatter should parse negative milliseconds

### DIFF
--- a/src/main/java/org/joda/time/format/PeriodFormatterBuilder.java
+++ b/src/main/java/org/joda/time/format/PeriodFormatterBuilder.java
@@ -1653,7 +1653,7 @@ public class PeriodFormatterBuilder {
                             fractValue *= 10;
                         }
                     }
-                    if (wholeValue < 0) {
+                    if (c == '-') {
                         fractValue = -fractValue;
                     }
                 }


### PR DESCRIPTION
wholeValue may be exactly zero.  We should instead check the sign of the entire text/value.