### PR TITLE
Added location info for timezones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,9 @@
             <argument>etcetera</argument>
             <argument>backward</argument>
             <argument>systemv</argument>
+	    <argument>iso3166.tab</argument>
+            <argument>zone.tab</argument>
+            <argument>zone1970.tab</argument>
           </arguments>
         </configuration>
       </plugin>

--- a/src/main/java/org/joda/time/DateTimeZone.java
+++ b/src/main/java/org/joda/time/DateTimeZone.java
@@ -659,7 +659,7 @@ public abstract class DateTimeZone implements Serializable {
     //--------------------------------------------------------------------
 
     private final String iID;
-
+    private TimeZoneLocationInfo iLocationInfo;
     /**
      * Constructor.
      * 
@@ -671,8 +671,23 @@ public abstract class DateTimeZone implements Serializable {
             throw new IllegalArgumentException("Id must not be null");
         }
         iID = id;
+        iLocationInfo = null;
     }
 
+    /**
+     * Constructor.
+     * 
+     * @param id  			the id to use
+     * @param locationInfo  the location info for this timezone
+     * @throws IllegalArgumentException if the id is null
+     */
+    protected DateTimeZone(String id, TimeZoneLocationInfo locationInfo) {
+        if (id == null) {
+            throw new IllegalArgumentException("Id must not be null");
+        }
+        iID = id;
+        iLocationInfo = locationInfo;
+    }
     // Principal methods
     //--------------------------------------------------------------------
 
@@ -685,7 +700,24 @@ public abstract class DateTimeZone implements Serializable {
     public final String getID() {
         return iID;
     }
+    
 
+    /**
+     * Gets the location-info of this datetime zone.
+     * 
+     * @return the location-info of this datetime zone
+     */
+    public TimeZoneLocationInfo getLocationInfo() {
+		return iLocationInfo;
+	}
+
+    /**
+     * Sets the location-info of this datetime zone.
+     */
+	public void setLocationInfo(TimeZoneLocationInfo locationInfo) {
+		this.iLocationInfo = locationInfo;
+	}
+	
     /**
      * Returns a non-localized name that is unique to this time zone. It can be
      * combined with id to form a unique key for fetching localized names.
@@ -1267,7 +1299,7 @@ public abstract class DateTimeZone implements Serializable {
         return new Stub(iID);
     }
 
-    /**
+	/**
      * Used to serialize DateTimeZones by id.
      */
     private static final class Stub implements Serializable {

--- a/src/main/java/org/joda/time/TimeZoneLocationInfo.java
+++ b/src/main/java/org/joda/time/TimeZoneLocationInfo.java
@@ -1,0 +1,74 @@
+package org.joda.time;
+
+import java.util.HashMap;
+
+public class TimeZoneLocationInfo {
+    public String getLatitude() {
+		return latitude;
+	}
+
+	public void setLatitude(String latitude) {
+		this.latitude = latitude;
+	}
+
+	public String getLongitude() {
+		return longitude;
+	}
+
+	@Override
+	public String toString() {
+		return "LocationInfo [latitude=" + latitude + ", longitude="
+				+ longitude + ", comments=" + comments + ", countries="
+				+ countries + "]";
+	}
+
+	public void setLongitude(String longitude) {
+		this.longitude = longitude;
+	}
+
+	public String getComments() {
+		return comments;
+	}
+
+	public void setComments(String comments) {
+		this.comments = comments;
+	}
+
+	public HashMap<String, String> getCountries() {
+		return countries;
+	}
+
+	public void setCountries(HashMap<String, String> countries) {
+		this.countries = countries;
+	}
+
+	private String latitude;
+    private String longitude;
+    private String comments;
+    private HashMap<String, String> countries;
+
+    public TimeZoneLocationInfo(String lat, String lon, String com, HashMap<String, String> countries) {
+        latitude = lat;
+        longitude = lon;
+        comments = com;
+        this.countries = countries;
+    }
+    
+    public TimeZoneLocationInfo(String lat, String lon, String com, String countries) {
+    	countries = countries.substring(1, countries.length()-1);
+        HashMap<String, String> countriesMap = new HashMap<String, String>();
+        String[] pairs = countries.split(",");
+        
+        for(int index=0; index<pairs.length; index++) {
+        	String pair = pairs[index];
+        	String[] values = pair.split("=");
+        	if(values.length==2) {
+        		countriesMap.put(values[0].trim(), values[1].trim());
+        	}
+        }
+        latitude = lat;
+        longitude = lon;
+        comments = com;
+        this.countries = countriesMap;
+    }
+}

--- a/src/main/java/org/joda/time/tz/CachedDateTimeZone.java
+++ b/src/main/java/org/joda/time/tz/CachedDateTimeZone.java
@@ -84,7 +84,7 @@ public class CachedDateTimeZone extends DateTimeZone {
     private final transient Info[] iInfoCache = new Info[cInfoCacheMask + 1];
 
     private CachedDateTimeZone(DateTimeZone zone) {
-        super(zone.getID());
+        super(zone.getID(), zone.getLocationInfo());
         iZone = zone;
     }
 

--- a/src/main/java/org/joda/time/tz/FixedDateTimeZone.java
+++ b/src/main/java/org/joda/time/tz/FixedDateTimeZone.java
@@ -16,6 +16,7 @@
 package org.joda.time.tz;
 
 import org.joda.time.DateTimeZone;
+import org.joda.time.TimeZoneLocationInfo;
 
 /**
  * Basic DateTimeZone implementation that has a fixed name key and offsets.
@@ -40,6 +41,16 @@ public final class FixedDateTimeZone extends DateTimeZone {
         iWallOffset = wallOffset;
         iStandardOffset = standardOffset;
     }
+    /**
+     * Constructor with location-info.
+     */
+    public FixedDateTimeZone(String id, String nameKey,
+        int wallOffset, int standardOffset, TimeZoneLocationInfo locationInfo) {
+		super(id, locationInfo);
+		iNameKey = nameKey;
+		iWallOffset = wallOffset;
+		iStandardOffset = standardOffset;
+	}
 
     public String getNameKey(long instant) {
         return iNameKey;

--- a/src/main/java/org/joda/time/tz/ZoneInfoCompiler.java
+++ b/src/main/java/org/joda/time/tz/ZoneInfoCompiler.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.joda.time.Chronology;
 import org.joda.time.DateTime;
@@ -39,6 +41,7 @@ import org.joda.time.DateTimeField;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.MutableDateTime;
+import org.joda.time.TimeZoneLocationInfo;
 import org.joda.time.chrono.ISOChronology;
 import org.joda.time.chrono.LenientChronology;
 import org.joda.time.format.DateTimeFormatter;
@@ -340,12 +343,20 @@ public class ZoneInfoCompiler {
 
     // List String pairs to link.
     private List<String> iBackLinks;
+    
+    //Maps country codes to location-info of the timezone 
+    private Map<String, TimeZoneLocationInfo> timeZoneCountry;
+    
+    //Maps country codes to country names
+    private Map<String, String> countryCodes;
 
     public ZoneInfoCompiler() {
         iRuleSets = new HashMap<String, RuleSet>();
         iZones = new ArrayList<Zone>();
         iGoodLinks = new ArrayList<String>();
         iBackLinks = new ArrayList<String>();
+        timeZoneCountry = new HashMap<String, TimeZoneLocationInfo>();
+        countryCodes = new HashMap<String, String>();
     }
 
     /**
@@ -357,8 +368,16 @@ public class ZoneInfoCompiler {
     public Map<String, DateTimeZone> compile(File outputDir, File[] sources) throws IOException {
         if (sources != null) {
             for (int i=0; i<sources.length; i++) {
+            	String fileName = sources[i].getName();
                 BufferedReader in = new BufferedReader(new FileReader(sources[i]));
-                parseDataFile(in, "backward".equals(sources[i].getName()));
+                
+                if(fileName.equals("zone.tab") || fileName.equals("zone1970.tab")) {
+                	parseTimeZoneCountry(in);
+                } else if(fileName.equals("iso3166.tab")) {
+                	parseCountryCodes(in);
+                } else {
+                	parseDataFile(in, "backward".equals(fileName));
+                }
                 in.close();
             }
         }
@@ -383,7 +402,8 @@ public class ZoneInfoCompiler {
             Zone zone = iZones.get(i);
             DateTimeZoneBuilder builder = new DateTimeZoneBuilder();
             zone.addToBuilder(builder, iRuleSets);
-            DateTimeZone tz = builder.toDateTimeZone(zone.iName, true);
+            TimeZoneLocationInfo locationInfo = timeZoneCountry.get(zone.iName);
+            DateTimeZone tz = builder.toDateTimeZone(zone.iName, true, locationInfo);
             if (test(tz.getID(), tz)) {
                 map.put(tz.getID(), tz);
                 sourceMap.put(tz.getID(), zone);
@@ -403,7 +423,8 @@ public class ZoneInfoCompiler {
             } else {
                 DateTimeZoneBuilder builder = new DateTimeZoneBuilder();
                 sourceZone.addToBuilder(builder, iRuleSets);
-                DateTimeZone revived = builder.toDateTimeZone(alias, true);
+                TimeZoneLocationInfo locationInfo = timeZoneCountry.get(alias);
+                DateTimeZone revived = builder.toDateTimeZone(alias, true, locationInfo);
                 if (test(revived.getID(), revived)) {
                     map.put(revived.getID(), revived);
                     if (outputDir != null) {
@@ -468,23 +489,86 @@ public class ZoneInfoCompiler {
             file.getParentFile().mkdirs();
         }
         OutputStream out = new FileOutputStream(file);
+        TimeZoneLocationInfo locationInfo = null;
         try {
-            builder.writeTo(tz.getID(), out);
+        	locationInfo = timeZoneCountry.get(tz.getID());
+            builder.writeTo(tz.getID(), out, locationInfo);
         } finally {
             out.close();
         }
-
         // Test if it can be read back.
         InputStream in = new FileInputStream(file);
         DateTimeZone tz2 = DateTimeZoneBuilder.readFrom(in, tz.getID());
         in.close();
-
         if (!tz.equals(tz2)) {
             System.out.println("*e* Error in " + tz.getID() +
                                ": Didn't read properly from file");
         }
     }
 
+    public void parseTimeZoneCountry(BufferedReader in) throws IOException {
+    	String line;
+        while ((line = in.readLine()) != null) {
+        	String trimmed = line.trim();
+            if (trimmed.length() == 0 || trimmed.charAt(0) == '#') {
+                continue;
+            }
+            int index = line.indexOf('#');
+            if (index >= 0) {
+                line = line.substring(0, index);
+            }
+            StringTokenizer st = new StringTokenizer(line, " \t");
+            if(st.hasMoreTokens()) {
+            	String codes = st.nextToken();
+            	String coord = st.nextToken();
+                String timezone = st.nextToken();
+                String comment = "";
+                while(st.hasMoreTokens()) {
+                	comment += st.nextToken() + " ";
+                }
+                comment = comment.trim();
+                HashMap<String, String> countries = new HashMap<String, String>();
+                StringTokenizer st2 = new StringTokenizer(codes, ",");
+                while(st2.hasMoreTokens()) {
+                	String code = st2.nextToken();
+                	countries.put(code, countryCodes.get(code));
+                }
+                String pattern = "([+-]\\d+)([+-]\\d+)";
+                Pattern r = Pattern.compile(pattern);
+                Matcher m = r.matcher(coord);
+                m.matches();
+                String latitude = m.groupCount() >= 1 ? m.group(1) : "";
+                String longitude = m.groupCount() >= 2 ? m.group(2) : "";
+                TimeZoneLocationInfo locationInfo = new TimeZoneLocationInfo(latitude, longitude, comment, countries);
+                timeZoneCountry.put(timezone, locationInfo);
+            }
+        }
+    }
+    
+    public void parseCountryCodes(BufferedReader in) throws IOException {
+    	String line;
+        while ((line = in.readLine()) != null) {
+        	String trimmed = line.trim();
+            if (trimmed.length() == 0 || trimmed.charAt(0) == '#') {
+                continue;
+            }
+            int index = line.indexOf('#');
+            if (index >= 0) {
+                line = line.substring(0, index);
+            }
+            StringTokenizer st = new StringTokenizer(line, " \t");
+            if(st.hasMoreTokens()) {
+            	String code = st.nextToken();
+            	String country = "";
+            	while(st.hasMoreTokens()) {
+                	country += st.nextToken() + " ";
+                }
+            	country = country.trim();
+                countryCodes.put(code, country);
+            }
+        }
+    }
+    
     public void parseDataFile(BufferedReader in, boolean backward) throws IOException {
         Zone zone = null;
         String line;
@@ -752,7 +836,7 @@ public class ZoneInfoCompiler {
                 "LetterS: " + iLetterS + "\n";
         }
     }
-
+    
     private static class RuleSet {
         private List<Rule> iRules;
 

--- a/src/main/java/org/joda/time/tz/src/iso3166.tab
+++ b/src/main/java/org/joda/time/tz/src/iso3166.tab
@@ -1,0 +1,275 @@
+# ISO 3166 alpha-2 country codes
+#
+# This file is in the public domain, so clarified as of
+# 2009-05-17 by Arthur David Olson.
+#
+# From Paul Eggert (2014-07-18):
+# This file contains a table of two-letter country codes.  Columns are
+# separated by a single tab.  Lines beginning with '#' are comments.
+# Although all text currently uses ASCII encoding, this is planned to
+# change to UTF-8 soon.  The columns of the table are as follows:
+#
+# 1.  ISO 3166-1 alpha-2 country code, current as of
+#     ISO 3166-1 Newsletter VI-16 (2013-07-11).  See: Updates on ISO 3166
+#   http://www.iso.org/iso/home/standards/country_codes/updates_on_iso_3166.htm
+# 2.  The usual English name for the coded region,
+#     chosen so that alphabetic sorting of subsets produces helpful lists.
+#     This is not the same as the English name in the ISO 3166 tables.
+#
+# The table is sorted by country code.
+#
+# This table is intended as an aid for users, to help them select time
+# zone data appropriate for their practical needs.  It is not intended
+# to take or endorse any position on legal or territorial claims.
+#
+#country-
+#code	name of country, territory, area, or subdivision
+AD	Andorra
+AE	United Arab Emirates
+AF	Afghanistan
+AG	Antigua & Barbuda
+AI	Anguilla
+AL	Albania
+AM	Armenia
+AO	Angola
+AQ	Antarctica
+AR	Argentina
+AS	Samoa (American)
+AT	Austria
+AU	Australia
+AW	Aruba
+AX	Aaland Islands
+AZ	Azerbaijan
+BA	Bosnia & Herzegovina
+BB	Barbados
+BD	Bangladesh
+BE	Belgium
+BF	Burkina Faso
+BG	Bulgaria
+BH	Bahrain
+BI	Burundi
+BJ	Benin
+BL	St Barthelemy
+BM	Bermuda
+BN	Brunei
+BO	Bolivia
+BQ	Caribbean Netherlands
+BR	Brazil
+BS	Bahamas
+BT	Bhutan
+BV	Bouvet Island
+BW	Botswana
+BY	Belarus
+BZ	Belize
+CA	Canada
+CC	Cocos (Keeling) Islands
+CD	Congo (Dem. Rep.)
+CF	Central African Rep.
+CG	Congo (Rep.)
+CH	Switzerland
+CI	Cote d'Ivoire
+CK	Cook Islands
+CL	Chile
+CM	Cameroon
+CN	China
+CO	Colombia
+CR	Costa Rica
+CU	Cuba
+CV	Cape Verde
+CW	Curacao
+CX	Christmas Island
+CY	Cyprus
+CZ	Czech Republic
+DE	Germany
+DJ	Djibouti
+DK	Denmark
+DM	Dominica
+DO	Dominican Republic
+DZ	Algeria
+EC	Ecuador
+EE	Estonia
+EG	Egypt
+EH	Western Sahara
+ER	Eritrea
+ES	Spain
+ET	Ethiopia
+FI	Finland
+FJ	Fiji
+FK	Falkland Islands
+FM	Micronesia
+FO	Faroe Islands
+FR	France
+GA	Gabon
+GB	Britain (UK)
+GD	Grenada
+GE	Georgia
+GF	French Guiana
+GG	Guernsey
+GH	Ghana
+GI	Gibraltar
+GL	Greenland
+GM	Gambia
+GN	Guinea
+GP	Guadeloupe
+GQ	Equatorial Guinea
+GR	Greece
+GS	South Georgia & the South Sandwich Islands
+GT	Guatemala
+GU	Guam
+GW	Guinea-Bissau
+GY	Guyana
+HK	Hong Kong
+HM	Heard Island & McDonald Islands
+HN	Honduras
+HR	Croatia
+HT	Haiti
+HU	Hungary
+ID	Indonesia
+IE	Ireland
+IL	Israel
+IM	Isle of Man
+IN	India
+IO	British Indian Ocean Territory
+IQ	Iraq
+IR	Iran
+IS	Iceland
+IT	Italy
+JE	Jersey
+JM	Jamaica
+JO	Jordan
+JP	Japan
+KE	Kenya
+KG	Kyrgyzstan
+KH	Cambodia
+KI	Kiribati
+KM	Comoros
+KN	St Kitts & Nevis
+KP	Korea (North)
+KR	Korea (South)
+KW	Kuwait
+KY	Cayman Islands
+KZ	Kazakhstan
+LA	Laos
+LB	Lebanon
+LC	St Lucia
+LI	Liechtenstein
+LK	Sri Lanka
+LR	Liberia
+LS	Lesotho
+LT	Lithuania
+LU	Luxembourg
+LV	Latvia
+LY	Libya
+MA	Morocco
+MC	Monaco
+MD	Moldova
+ME	Montenegro
+MF	St Martin (French part)
+MG	Madagascar
+MH	Marshall Islands
+MK	Macedonia
+ML	Mali
+MM	Myanmar (Burma)
+MN	Mongolia
+MO	Macau
+MP	Northern Mariana Islands
+MQ	Martinique
+MR	Mauritania
+MS	Montserrat
+MT	Malta
+MU	Mauritius
+MV	Maldives
+MW	Malawi
+MX	Mexico
+MY	Malaysia
+MZ	Mozambique
+NA	Namibia
+NC	New Caledonia
+NE	Niger
+NF	Norfolk Island
+NG	Nigeria
+NI	Nicaragua
+NL	Netherlands
+NO	Norway
+NP	Nepal
+NR	Nauru
+NU	Niue
+NZ	New Zealand
+OM	Oman
+PA	Panama
+PE	Peru
+PF	French Polynesia
+PG	Papua New Guinea
+PH	Philippines
+PK	Pakistan
+PL	Poland
+PM	St Pierre & Miquelon
+PN	Pitcairn
+PR	Puerto Rico
+PS	Palestine
+PT	Portugal
+PW	Palau
+PY	Paraguay
+QA	Qatar
+RE	Reunion
+RO	Romania
+RS	Serbia
+RU	Russia
+RW	Rwanda
+SA	Saudi Arabia
+SB	Solomon Islands
+SC	Seychelles
+SD	Sudan
+SE	Sweden
+SG	Singapore
+SH	St Helena
+SI	Slovenia
+SJ	Svalbard & Jan Mayen
+SK	Slovakia
+SL	Sierra Leone
+SM	San Marino
+SN	Senegal
+SO	Somalia
+SR	Suriname
+SS	South Sudan
+ST	Sao Tome & Principe
+SV	El Salvador
+SX	St Maarten (Dutch part)
+SY	Syria
+SZ	Swaziland
+TC	Turks & Caicos Is
+TD	Chad
+TF	French Southern & Antarctic Lands
+TG	Togo
+TH	Thailand
+TJ	Tajikistan
+TK	Tokelau
+TL	East Timor
+TM	Turkmenistan
+TN	Tunisia
+TO	Tonga
+TR	Turkey
+TT	Trinidad & Tobago
+TV	Tuvalu
+TW	Taiwan
+TZ	Tanzania
+UA	Ukraine
+UG	Uganda
+UM	US minor outlying islands
+US	United States
+UY	Uruguay
+UZ	Uzbekistan
+VA	Vatican City
+VC	St Vincent
+VE	Venezuela
+VG	Virgin Islands (UK)
+VI	Virgin Islands (US)
+VN	Vietnam
+VU	Vanuatu
+WF	Wallis & Futuna
+WS	Samoa (western)
+YE	Yemen
+YT	Mayotte
+ZA	South Africa
+ZM	Zambia
+ZW	Zimbabwe

--- a/src/main/java/org/joda/time/tz/src/zone.tab
+++ b/src/main/java/org/joda/time/tz/src/zone.tab
@@ -1,0 +1,440 @@
+# tz zone descriptions (deprecated version)
+#
+# This file is in the public domain, so clarified as of
+# 2009-05-17 by Arthur David Olson.
+#
+# From Paul Eggert (2014-07-31):
+# This file is intended as a backward-compatibility aid for older programs.
+# New programs should use zone1970.tab.  This file is like zone1970.tab (see
+# zone1970.tab's comments), but with the following additional restrictions:
+#
+# 1.  This file contains only ASCII characters.
+# 2.  The first data column contains exactly one country code.
+#
+# Because of (2), each row stands for an area that is the intersection
+# of a region identified by a country code and of a zone where civil
+# clocks have agreed since 1970; this is a narrower definition than
+# that of zone1970.tab.
+#
+# This table is intended as an aid for users, to help them select time
+# zone data entries appropriate for their practical needs.  It is not
+# intended to take or endorse any position on legal or territorial claims.
+#
+#country-
+#code	coordinates	TZ			comments
+AD	+4230+00131	Europe/Andorra
+AE	+2518+05518	Asia/Dubai
+AF	+3431+06912	Asia/Kabul
+AG	+1703-06148	America/Antigua
+AI	+1812-06304	America/Anguilla
+AL	+4120+01950	Europe/Tirane
+AM	+4011+04430	Asia/Yerevan
+AO	-0848+01314	Africa/Luanda
+AQ	-7750+16636	Antarctica/McMurdo	McMurdo, South Pole, Scott (New Zealand time)
+AQ	-6734-06808	Antarctica/Rothera	Rothera Station, Adelaide Island
+AQ	-6448-06406	Antarctica/Palmer	Palmer Station, Anvers Island
+AQ	-6736+06253	Antarctica/Mawson	Mawson Station, Holme Bay
+AQ	-6835+07758	Antarctica/Davis	Davis Station, Vestfold Hills
+AQ	-6617+11031	Antarctica/Casey	Casey Station, Bailey Peninsula
+AQ	-7824+10654	Antarctica/Vostok	Vostok Station, Lake Vostok
+AQ	-6640+14001	Antarctica/DumontDUrville	Dumont-d'Urville Station, Adelie Land
+AQ	-690022+0393524	Antarctica/Syowa	Syowa Station, E Ongul I
+AQ	-720041+0023206	Antarctica/Troll	Troll Station, Queen Maud Land
+AR	-3436-05827	America/Argentina/Buenos_Aires	Buenos Aires (BA, CF)
+AR	-3124-06411	America/Argentina/Cordoba	most locations (CB, CC, CN, ER, FM, MN, SE, SF)
+AR	-2447-06525	America/Argentina/Salta	(SA, LP, NQ, RN)
+AR	-2411-06518	America/Argentina/Jujuy	Jujuy (JY)
+AR	-2649-06513	America/Argentina/Tucuman	Tucuman (TM)
+AR	-2828-06547	America/Argentina/Catamarca	Catamarca (CT), Chubut (CH)
+AR	-2926-06651	America/Argentina/La_Rioja	La Rioja (LR)
+AR	-3132-06831	America/Argentina/San_Juan	San Juan (SJ)
+AR	-3253-06849	America/Argentina/Mendoza	Mendoza (MZ)
+AR	-3319-06621	America/Argentina/San_Luis	San Luis (SL)
+AR	-5138-06913	America/Argentina/Rio_Gallegos	Santa Cruz (SC)
+AR	-5448-06818	America/Argentina/Ushuaia	Tierra del Fuego (TF)
+AS	-1416-17042	Pacific/Pago_Pago
+AT	+4813+01620	Europe/Vienna
+AU	-3133+15905	Australia/Lord_Howe	Lord Howe Island
+AU	-5430+15857	Antarctica/Macquarie	Macquarie Island
+AU	-4253+14719	Australia/Hobart	Tasmania - most locations
+AU	-3956+14352	Australia/Currie	Tasmania - King Island
+AU	-3749+14458	Australia/Melbourne	Victoria
+AU	-3352+15113	Australia/Sydney	New South Wales - most locations
+AU	-3157+14127	Australia/Broken_Hill	New South Wales - Yancowinna
+AU	-2728+15302	Australia/Brisbane	Queensland - most locations
+AU	-2016+14900	Australia/Lindeman	Queensland - Holiday Islands
+AU	-3455+13835	Australia/Adelaide	South Australia
+AU	-1228+13050	Australia/Darwin	Northern Territory
+AU	-3157+11551	Australia/Perth	Western Australia - most locations
+AU	-3143+12852	Australia/Eucla	Western Australia - Eucla area
+AW	+1230-06958	America/Aruba
+AX	+6006+01957	Europe/Mariehamn
+AZ	+4023+04951	Asia/Baku
+BA	+4352+01825	Europe/Sarajevo
+BB	+1306-05937	America/Barbados
+BD	+2343+09025	Asia/Dhaka
+BE	+5050+00420	Europe/Brussels
+BF	+1222-00131	Africa/Ouagadougou
+BG	+4241+02319	Europe/Sofia
+BH	+2623+05035	Asia/Bahrain
+BI	-0323+02922	Africa/Bujumbura
+BJ	+0629+00237	Africa/Porto-Novo
+BL	+1753-06251	America/St_Barthelemy
+BM	+3217-06446	Atlantic/Bermuda
+BN	+0456+11455	Asia/Brunei
+BO	-1630-06809	America/La_Paz
+BQ	+120903-0681636	America/Kralendijk
+BR	-0351-03225	America/Noronha	Atlantic islands
+BR	-0127-04829	America/Belem	Amapa, E Para
+BR	-0343-03830	America/Fortaleza	NE Brazil (MA, PI, CE, RN, PB)
+BR	-0803-03454	America/Recife	Pernambuco
+BR	-0712-04812	America/Araguaina	Tocantins
+BR	-0940-03543	America/Maceio	Alagoas, Sergipe
+BR	-1259-03831	America/Bahia	Bahia
+BR	-2332-04637	America/Sao_Paulo	S & SE Brazil (GO, DF, MG, ES, RJ, SP, PR, SC, RS)
+BR	-2027-05437	America/Campo_Grande	Mato Grosso do Sul
+BR	-1535-05605	America/Cuiaba	Mato Grosso
+BR	-0226-05452	America/Santarem	W Para
+BR	-0846-06354	America/Porto_Velho	Rondonia
+BR	+0249-06040	America/Boa_Vista	Roraima
+BR	-0308-06001	America/Manaus	E Amazonas
+BR	-0640-06952	America/Eirunepe	W Amazonas
+BR	-0958-06748	America/Rio_Branco	Acre
+BS	+2505-07721	America/Nassau
+BT	+2728+08939	Asia/Thimphu
+BW	-2439+02555	Africa/Gaborone
+BY	+5354+02734	Europe/Minsk
+BZ	+1730-08812	America/Belize
+CA	+4734-05243	America/St_Johns	Newfoundland Time, including SE Labrador
+CA	+4439-06336	America/Halifax	Atlantic Time - Nova Scotia (most places), PEI
+CA	+4612-05957	America/Glace_Bay	Atlantic Time - Nova Scotia - places that did not observe DST 1966-1971
+CA	+4606-06447	America/Moncton	Atlantic Time - New Brunswick
+CA	+5320-06025	America/Goose_Bay	Atlantic Time - Labrador - most locations
+CA	+5125-05707	America/Blanc-Sablon	Atlantic Standard Time - Quebec - Lower North Shore
+CA	+4339-07923	America/Toronto	Eastern Time - Ontario & Quebec - most locations
+CA	+4901-08816	America/Nipigon	Eastern Time - Ontario & Quebec - places that did not observe DST 1967-1973
+CA	+4823-08915	America/Thunder_Bay	Eastern Time - Thunder Bay, Ontario
+CA	+6344-06828	America/Iqaluit	Eastern Time - east Nunavut - most locations
+CA	+6608-06544	America/Pangnirtung	Eastern Time - Pangnirtung, Nunavut
+CA	+744144-0944945	America/Resolute	Central Time - Resolute, Nunavut
+CA	+484531-0913718	America/Atikokan	Eastern Standard Time - Atikokan, Ontario and Southampton I, Nunavut
+CA	+624900-0920459	America/Rankin_Inlet	Central Time - central Nunavut
+CA	+4953-09709	America/Winnipeg	Central Time - Manitoba & west Ontario
+CA	+4843-09434	America/Rainy_River	Central Time - Rainy River & Fort Frances, Ontario
+CA	+5024-10439	America/Regina	Central Standard Time - Saskatchewan - most locations
+CA	+5017-10750	America/Swift_Current	Central Standard Time - Saskatchewan - midwest
+CA	+5333-11328	America/Edmonton	Mountain Time - Alberta, east British Columbia & west Saskatchewan
+CA	+690650-1050310	America/Cambridge_Bay	Mountain Time - west Nunavut
+CA	+6227-11421	America/Yellowknife	Mountain Time - central Northwest Territories
+CA	+682059-1334300	America/Inuvik	Mountain Time - west Northwest Territories
+CA	+4906-11631	America/Creston	Mountain Standard Time - Creston, British Columbia
+CA	+5946-12014	America/Dawson_Creek	Mountain Standard Time - Dawson Creek & Fort Saint John, British Columbia
+CA	+4916-12307	America/Vancouver	Pacific Time - west British Columbia
+CA	+6043-13503	America/Whitehorse	Pacific Time - south Yukon
+CA	+6404-13925	America/Dawson	Pacific Time - north Yukon
+CC	-1210+09655	Indian/Cocos
+CD	-0418+01518	Africa/Kinshasa	west Dem. Rep. of Congo
+CD	-1140+02728	Africa/Lubumbashi	east Dem. Rep. of Congo
+CF	+0422+01835	Africa/Bangui
+CG	-0416+01517	Africa/Brazzaville
+CH	+4723+00832	Europe/Zurich
+CI	+0519-00402	Africa/Abidjan
+CK	-2114-15946	Pacific/Rarotonga
+CL	-3327-07040	America/Santiago	most locations
+CL	-2709-10926	Pacific/Easter	Easter Island
+CM	+0403+00942	Africa/Douala
+CN	+3114+12128	Asia/Shanghai	Beijing Time
+CN	+4348+08735	Asia/Urumqi	Xinjiang Time
+CO	+0436-07405	America/Bogota
+CR	+0956-08405	America/Costa_Rica
+CU	+2308-08222	America/Havana
+CV	+1455-02331	Atlantic/Cape_Verde
+CW	+1211-06900	America/Curacao
+CX	-1025+10543	Indian/Christmas
+CY	+3510+03322	Asia/Nicosia
+CZ	+5005+01426	Europe/Prague
+DE	+5230+01322	Europe/Berlin	most locations
+DE	+4742+00841	Europe/Busingen	Busingen
+DJ	+1136+04309	Africa/Djibouti
+DK	+5540+01235	Europe/Copenhagen
+DM	+1518-06124	America/Dominica
+DO	+1828-06954	America/Santo_Domingo
+DZ	+3647+00303	Africa/Algiers
+EC	-0210-07950	America/Guayaquil	mainland
+EC	-0054-08936	Pacific/Galapagos	Galapagos Islands
+EE	+5925+02445	Europe/Tallinn
+EG	+3003+03115	Africa/Cairo
+EH	+2709-01312	Africa/El_Aaiun
+ER	+1520+03853	Africa/Asmara
+ES	+4024-00341	Europe/Madrid	mainland
+ES	+3553-00519	Africa/Ceuta	Ceuta & Melilla
+ES	+2806-01524	Atlantic/Canary	Canary Islands
+ET	+0902+03842	Africa/Addis_Ababa
+FI	+6010+02458	Europe/Helsinki
+FJ	-1808+17825	Pacific/Fiji
+FK	-5142-05751	Atlantic/Stanley
+FM	+0725+15147	Pacific/Chuuk	Chuuk (Truk) and Yap
+FM	+0658+15813	Pacific/Pohnpei	Pohnpei (Ponape)
+FM	+0519+16259	Pacific/Kosrae	Kosrae
+FO	+6201-00646	Atlantic/Faroe
+FR	+4852+00220	Europe/Paris
+GA	+0023+00927	Africa/Libreville
+GB	+513030-0000731	Europe/London
+GD	+1203-06145	America/Grenada
+GE	+4143+04449	Asia/Tbilisi
+GF	+0456-05220	America/Cayenne
+GG	+4927-00232	Europe/Guernsey
+GH	+0533-00013	Africa/Accra
+GI	+3608-00521	Europe/Gibraltar
+GL	+6411-05144	America/Godthab	most locations
+GL	+7646-01840	America/Danmarkshavn	east coast, north of Scoresbysund
+GL	+7029-02158	America/Scoresbysund	Scoresbysund / Ittoqqortoormiit
+GL	+7634-06847	America/Thule	Thule / Pituffik
+GM	+1328-01639	Africa/Banjul
+GN	+0931-01343	Africa/Conakry
+GP	+1614-06132	America/Guadeloupe
+GQ	+0345+00847	Africa/Malabo
+GR	+3758+02343	Europe/Athens
+GS	-5416-03632	Atlantic/South_Georgia
+GT	+1438-09031	America/Guatemala
+GU	+1328+14445	Pacific/Guam
+GW	+1151-01535	Africa/Bissau
+GY	+0648-05810	America/Guyana
+HK	+2217+11409	Asia/Hong_Kong
+HN	+1406-08713	America/Tegucigalpa
+HR	+4548+01558	Europe/Zagreb
+HT	+1832-07220	America/Port-au-Prince
+HU	+4730+01905	Europe/Budapest
+ID	-0610+10648	Asia/Jakarta	Java & Sumatra
+ID	-0002+10920	Asia/Pontianak	west & central Borneo
+ID	-0507+11924	Asia/Makassar	east & south Borneo, Sulawesi (Celebes), Bali, Nusa Tengarra, west Timor
+ID	-0232+14042	Asia/Jayapura	west New Guinea (Irian Jaya) & Malukus (Moluccas)
+IE	+5320-00615	Europe/Dublin
+IL	+314650+0351326	Asia/Jerusalem
+IM	+5409-00428	Europe/Isle_of_Man
+IN	+2232+08822	Asia/Kolkata
+IO	-0720+07225	Indian/Chagos
+IQ	+3321+04425	Asia/Baghdad
+IR	+3540+05126	Asia/Tehran
+IS	+6409-02151	Atlantic/Reykjavik
+IT	+4154+01229	Europe/Rome
+JE	+4912-00207	Europe/Jersey
+JM	+175805-0764736	America/Jamaica
+JO	+3157+03556	Asia/Amman
+JP	+353916+1394441	Asia/Tokyo
+KE	-0117+03649	Africa/Nairobi
+KG	+4254+07436	Asia/Bishkek
+KH	+1133+10455	Asia/Phnom_Penh
+KI	+0125+17300	Pacific/Tarawa	Gilbert Islands
+KI	-0308-17105	Pacific/Enderbury	Phoenix Islands
+KI	+0152-15720	Pacific/Kiritimati	Line Islands
+KM	-1141+04316	Indian/Comoro
+KN	+1718-06243	America/St_Kitts
+KP	+3901+12545	Asia/Pyongyang
+KR	+3733+12658	Asia/Seoul
+KW	+2920+04759	Asia/Kuwait
+KY	+1918-08123	America/Cayman
+KZ	+4315+07657	Asia/Almaty	most locations
+KZ	+4448+06528	Asia/Qyzylorda	Qyzylorda (Kyzylorda, Kzyl-Orda)
+KZ	+5017+05710	Asia/Aqtobe	Aqtobe (Aktobe)
+KZ	+4431+05016	Asia/Aqtau	Atyrau (Atirau, Gur'yev), Mangghystau (Mankistau)
+KZ	+5113+05121	Asia/Oral	West Kazakhstan
+LA	+1758+10236	Asia/Vientiane
+LB	+3353+03530	Asia/Beirut
+LC	+1401-06100	America/St_Lucia
+LI	+4709+00931	Europe/Vaduz
+LK	+0656+07951	Asia/Colombo
+LR	+0618-01047	Africa/Monrovia
+LS	-2928+02730	Africa/Maseru
+LT	+5441+02519	Europe/Vilnius
+LU	+4936+00609	Europe/Luxembourg
+LV	+5657+02406	Europe/Riga
+LY	+3254+01311	Africa/Tripoli
+MA	+3339-00735	Africa/Casablanca
+MC	+4342+00723	Europe/Monaco
+MD	+4700+02850	Europe/Chisinau
+ME	+4226+01916	Europe/Podgorica
+MF	+1804-06305	America/Marigot
+MG	-1855+04731	Indian/Antananarivo
+MH	+0709+17112	Pacific/Majuro	most locations
+MH	+0905+16720	Pacific/Kwajalein	Kwajalein
+MK	+4159+02126	Europe/Skopje
+ML	+1239-00800	Africa/Bamako
+MM	+1647+09610	Asia/Rangoon
+MN	+4755+10653	Asia/Ulaanbaatar	most locations
+MN	+4801+09139	Asia/Hovd	Bayan-Olgiy, Govi-Altai, Hovd, Uvs, Zavkhan
+MN	+4804+11430	Asia/Choibalsan	Dornod, Sukhbaatar
+MO	+2214+11335	Asia/Macau
+MP	+1512+14545	Pacific/Saipan
+MQ	+1436-06105	America/Martinique
+MR	+1806-01557	Africa/Nouakchott
+MS	+1643-06213	America/Montserrat
+MT	+3554+01431	Europe/Malta
+MU	-2010+05730	Indian/Mauritius
+MV	+0410+07330	Indian/Maldives
+MW	-1547+03500	Africa/Blantyre
+MX	+1924-09909	America/Mexico_City	Central Time - most locations
+MX	+2105-08646	America/Cancun	Eastern Standard Time - Quintana Roo
+MX	+2058-08937	America/Merida	Central Time - Campeche, Yucatan
+MX	+2540-10019	America/Monterrey	Mexican Central Time - Coahuila, Durango, Nuevo Leon, Tamaulipas away from US border
+MX	+2550-09730	America/Matamoros	US Central Time - Coahuila, Durango, Nuevo Leon, Tamaulipas near US border
+MX	+2313-10625	America/Mazatlan	Mountain Time - S Baja, Nayarit, Sinaloa
+MX	+2838-10605	America/Chihuahua	Mexican Mountain Time - Chihuahua away from US border
+MX	+2934-10425	America/Ojinaga	US Mountain Time - Chihuahua near US border
+MX	+2904-11058	America/Hermosillo	Mountain Standard Time - Sonora
+MX	+3232-11701	America/Tijuana	US Pacific Time - Baja California near US border
+MX	+3018-11452	America/Santa_Isabel	Mexican Pacific Time - Baja California away from US border
+MX	+2048-10515	America/Bahia_Banderas	Mexican Central Time - Bahia de Banderas
+MY	+0310+10142	Asia/Kuala_Lumpur	peninsular Malaysia
+MY	+0133+11020	Asia/Kuching	Sabah & Sarawak
+MZ	-2558+03235	Africa/Maputo
+NA	-2234+01706	Africa/Windhoek
+NC	-2216+16627	Pacific/Noumea
+NE	+1331+00207	Africa/Niamey
+NF	-2903+16758	Pacific/Norfolk
+NG	+0627+00324	Africa/Lagos
+NI	+1209-08617	America/Managua
+NL	+5222+00454	Europe/Amsterdam
+NO	+5955+01045	Europe/Oslo
+NP	+2743+08519	Asia/Kathmandu
+NR	-0031+16655	Pacific/Nauru
+NU	-1901-16955	Pacific/Niue
+NZ	-3652+17446	Pacific/Auckland	most locations
+NZ	-4357-17633	Pacific/Chatham	Chatham Islands
+OM	+2336+05835	Asia/Muscat
+PA	+0858-07932	America/Panama
+PE	-1203-07703	America/Lima
+PF	-1732-14934	Pacific/Tahiti	Society Islands
+PF	-0900-13930	Pacific/Marquesas	Marquesas Islands
+PF	-2308-13457	Pacific/Gambier	Gambier Islands
+PG	-0930+14710	Pacific/Port_Moresby	most locations
+PG	-0613+15534	Pacific/Bougainville	Bougainville
+PH	+1435+12100	Asia/Manila
+PK	+2452+06703	Asia/Karachi
+PL	+5215+02100	Europe/Warsaw
+PM	+4703-05620	America/Miquelon
+PN	-2504-13005	Pacific/Pitcairn
+PR	+182806-0660622	America/Puerto_Rico
+PS	+3130+03428	Asia/Gaza	Gaza Strip
+PS	+313200+0350542	Asia/Hebron	West Bank
+PT	+3843-00908	Europe/Lisbon	mainland
+PT	+3238-01654	Atlantic/Madeira	Madeira Islands
+PT	+3744-02540	Atlantic/Azores	Azores
+PW	+0720+13429	Pacific/Palau
+PY	-2516-05740	America/Asuncion
+QA	+2517+05132	Asia/Qatar
+RE	-2052+05528	Indian/Reunion
+RO	+4426+02606	Europe/Bucharest
+RS	+4450+02030	Europe/Belgrade
+RU	+5443+02030	Europe/Kaliningrad	Moscow-01 - Kaliningrad
+RU	+554521+0373704	Europe/Moscow	Moscow+00 - west Russia
+RU	+4457+03406	Europe/Simferopol	Moscow+00 - Crimea
+RU	+4844+04425	Europe/Volgograd	Moscow+00 - Caspian Sea
+RU	+5312+05009	Europe/Samara	Moscow+00 (Moscow+01 after 2014-10-26) - Samara, Udmurtia
+RU	+5651+06036	Asia/Yekaterinburg	Moscow+02 - Urals
+RU	+5500+07324	Asia/Omsk	Moscow+03 - west Siberia
+RU	+5502+08255	Asia/Novosibirsk	Moscow+03 - Novosibirsk
+RU	+5345+08707	Asia/Novokuznetsk	Moscow+03 (Moscow+04 after 2014-10-26) - Kemerovo
+RU	+5601+09250	Asia/Krasnoyarsk	Moscow+04 - Yenisei River
+RU	+5216+10420	Asia/Irkutsk	Moscow+05 - Lake Baikal
+RU	+5203+11328	Asia/Chita	Moscow+06 (Moscow+05 after 2014-10-26) - Zabaykalsky
+RU	+6200+12940	Asia/Yakutsk	Moscow+06 - Lena River
+RU	+623923+1353314	Asia/Khandyga	Moscow+06 - Tomponsky, Ust-Maysky
+RU	+4310+13156	Asia/Vladivostok	Moscow+07 - Amur River
+RU	+4658+14242	Asia/Sakhalin	Moscow+07 - Sakhalin Island
+RU	+643337+1431336	Asia/Ust-Nera	Moscow+07 - Oymyakonsky
+RU	+5934+15048	Asia/Magadan	Moscow+08 (Moscow+07 after 2014-10-26) - Magadan
+RU	+6728+15343	Asia/Srednekolymsk	Moscow+08 - E Sakha, N Kuril Is
+RU	+5301+15839	Asia/Kamchatka	Moscow+08 (Moscow+09 after 2014-10-26) - Kamchatka
+RU	+6445+17729	Asia/Anadyr	Moscow+08 (Moscow+09 after 2014-10-26) - Bering Sea
+RW	-0157+03004	Africa/Kigali
+SA	+2438+04643	Asia/Riyadh
+SB	-0932+16012	Pacific/Guadalcanal
+SC	-0440+05528	Indian/Mahe
+SD	+1536+03232	Africa/Khartoum
+SE	+5920+01803	Europe/Stockholm
+SG	+0117+10351	Asia/Singapore
+SH	-1555-00542	Atlantic/St_Helena
+SI	+4603+01431	Europe/Ljubljana
+SJ	+7800+01600	Arctic/Longyearbyen
+SK	+4809+01707	Europe/Bratislava
+SL	+0830-01315	Africa/Freetown
+SM	+4355+01228	Europe/San_Marino
+SN	+1440-01726	Africa/Dakar
+SO	+0204+04522	Africa/Mogadishu
+SR	+0550-05510	America/Paramaribo
+SS	+0451+03136	Africa/Juba
+ST	+0020+00644	Africa/Sao_Tome
+SV	+1342-08912	America/El_Salvador
+SX	+180305-0630250	America/Lower_Princes
+SY	+3330+03618	Asia/Damascus
+SZ	-2618+03106	Africa/Mbabane
+TC	+2128-07108	America/Grand_Turk
+TD	+1207+01503	Africa/Ndjamena
+TF	-492110+0701303	Indian/Kerguelen
+TG	+0608+00113	Africa/Lome
+TH	+1345+10031	Asia/Bangkok
+TJ	+3835+06848	Asia/Dushanbe
+TK	-0922-17114	Pacific/Fakaofo
+TL	-0833+12535	Asia/Dili
+TM	+3757+05823	Asia/Ashgabat
+TN	+3648+01011	Africa/Tunis
+TO	-2110-17510	Pacific/Tongatapu
+TR	+4101+02858	Europe/Istanbul
+TT	+1039-06131	America/Port_of_Spain
+TV	-0831+17913	Pacific/Funafuti
+TW	+2503+12130	Asia/Taipei
+TZ	-0648+03917	Africa/Dar_es_Salaam
+UA	+5026+03031	Europe/Kiev	most locations
+UA	+4837+02218	Europe/Uzhgorod	Ruthenia
+UA	+4750+03510	Europe/Zaporozhye	Zaporozh'ye, E Lugansk / Zaporizhia, E Luhansk
+UG	+0019+03225	Africa/Kampala
+UM	+1645-16931	Pacific/Johnston	Johnston Atoll
+UM	+2813-17722	Pacific/Midway	Midway Islands
+UM	+1917+16637	Pacific/Wake	Wake Island
+US	+404251-0740023	America/New_York	Eastern Time
+US	+421953-0830245	America/Detroit	Eastern Time - Michigan - most locations
+US	+381515-0854534	America/Kentucky/Louisville	Eastern Time - Kentucky - Louisville area
+US	+364947-0845057	America/Kentucky/Monticello	Eastern Time - Kentucky - Wayne County
+US	+394606-0860929	America/Indiana/Indianapolis	Eastern Time - Indiana - most locations
+US	+384038-0873143	America/Indiana/Vincennes	Eastern Time - Indiana - Daviess, Dubois, Knox & Martin Counties
+US	+410305-0863611	America/Indiana/Winamac	Eastern Time - Indiana - Pulaski County
+US	+382232-0862041	America/Indiana/Marengo	Eastern Time - Indiana - Crawford County
+US	+382931-0871643	America/Indiana/Petersburg	Eastern Time - Indiana - Pike County
+US	+384452-0850402	America/Indiana/Vevay	Eastern Time - Indiana - Switzerland County
+US	+415100-0873900	America/Chicago	Central Time
+US	+375711-0864541	America/Indiana/Tell_City	Central Time - Indiana - Perry County
+US	+411745-0863730	America/Indiana/Knox	Central Time - Indiana - Starke County
+US	+450628-0873651	America/Menominee	Central Time - Michigan - Dickinson, Gogebic, Iron & Menominee Counties
+US	+470659-1011757	America/North_Dakota/Center	Central Time - North Dakota - Oliver County
+US	+465042-1012439	America/North_Dakota/New_Salem	Central Time - North Dakota - Morton County (except Mandan area)
+US	+471551-1014640	America/North_Dakota/Beulah	Central Time - North Dakota - Mercer County
+US	+394421-1045903	America/Denver	Mountain Time
+US	+433649-1161209	America/Boise	Mountain Time - south Idaho & east Oregon
+US	+332654-1120424	America/Phoenix	Mountain Standard Time - Arizona (except Navajo)
+US	+340308-1181434	America/Los_Angeles	Pacific Time
+US	+550737-1313435	America/Metlakatla	Pacific Standard Time - Annette Island, Alaska
+US	+611305-1495401	America/Anchorage	Alaska Time
+US	+581807-1342511	America/Juneau	Alaska Time - Alaska panhandle
+US	+571035-1351807	America/Sitka	Alaska Time - southeast Alaska panhandle
+US	+593249-1394338	America/Yakutat	Alaska Time - Alaska panhandle neck
+US	+643004-1652423	America/Nome	Alaska Time - west Alaska
+US	+515248-1763929	America/Adak	Aleutian Islands
+US	+211825-1575130	Pacific/Honolulu	Hawaii
+UY	-3453-05611	America/Montevideo
+UZ	+3940+06648	Asia/Samarkand	west Uzbekistan
+UZ	+4120+06918	Asia/Tashkent	east Uzbekistan
+VA	+415408+0122711	Europe/Vatican
+VC	+1309-06114	America/St_Vincent
+VE	+1030-06656	America/Caracas
+VG	+1827-06437	America/Tortola
+VI	+1821-06456	America/St_Thomas
+VN	+1045+10640	Asia/Ho_Chi_Minh
+VU	-1740+16825	Pacific/Efate
+WF	-1318-17610	Pacific/Wallis
+WS	-1350-17144	Pacific/Apia
+YE	+1245+04512	Asia/Aden
+YT	-1247+04514	Indian/Mayotte
+ZA	-2615+02800	Africa/Johannesburg
+ZM	-1525+02817	Africa/Lusaka
+ZW	-1750+03103	Africa/Harare

--- a/src/main/java/org/joda/time/tz/src/zone1970.tab
+++ b/src/main/java/org/joda/time/tz/src/zone1970.tab
@@ -1,0 +1,371 @@
+# tz zone descriptions
+#
+# This file is in the public domain.
+#
+# From Paul Eggert (2014-07-31):
+# This file contains a table where each row stands for a zone where
+# civil time stamps have agreed since 1970.  Columns are separated by
+# a single tab.  Lines beginning with '#' are comments.  All text uses
+# UTF-8 encoding.  The columns of the table are as follows:
+#
+# 1.  The countries that overlap the zone, as a comma-separated list
+#     of ISO 3166 2-character country codes.  See the file 'iso3166.tab'.
+# 2.  Latitude and longitude of the zone's principal location
+#     in ISO 6709 sign-degrees-minutes-seconds format,
+#     either +-DDMM+-DDDMM or +-DDMMSS+-DDDMMSS,
+#     first latitude (+ is north), then longitude (+ is east).
+# 3.  Zone name used in value of TZ environment variable.
+#     Please see the 'Theory' file for how zone names are chosen.
+#     If multiple zones overlap a country, each has a row in the
+#     table, with each column 1 containing the country code.
+# 4.  Comments; present if and only if a country has multiple zones.
+#
+# If a zone covers multiple countries, the most-populous city is used,
+# and that country is listed first in column 1; any other countries
+# are listed alphabetically by country code.  The table is sorted
+# first by country code, then (if possible) by an order within the
+# country that (1) makes some geographical sense, and (2) puts the
+# most populous zones first, where that does not contradict (1).
+#
+# This table is intended as an aid for users, to help them select time
+# zone data entries appropriate for their practical needs.  It is not
+# intended to take or endorse any position on legal or territorial claims.
+#
+#country-
+#codes	coordinates	TZ	comments
+AD	+4230+00131	Europe/Andorra
+AE,OM	+2518+05518	Asia/Dubai
+AF	+3431+06912	Asia/Kabul
+AL	+4120+01950	Europe/Tirane
+AM	+4011+04430	Asia/Yerevan
+AQ	-6734-06808	Antarctica/Rothera	Rothera Station, Adelaide Island
+AQ	-6448-06406	Antarctica/Palmer	Palmer Station, Anvers Island
+AQ	-6736+06253	Antarctica/Mawson	Mawson Station, Holme Bay
+AQ	-6835+07758	Antarctica/Davis	Davis Station, Vestfold Hills
+AQ	-6617+11031	Antarctica/Casey	Casey Station, Bailey Peninsula
+AQ	-7824+10654	Antarctica/Vostok	Vostok Station, Lake Vostok
+AQ	-6640+14001	Antarctica/DumontDUrville	Dumont-d'Urville Station, Adélie Land
+AQ	-690022+0393524	Antarctica/Syowa	Syowa Station, E Ongul I
+AQ	-720041+0023206	Antarctica/Troll	Troll Station, Queen Maud Land
+AR	-3436-05827	America/Argentina/Buenos_Aires	Buenos Aires (BA, CF)
+AR	-3124-06411	America/Argentina/Cordoba	most locations (CB, CC, CN, ER, FM, MN, SE, SF)
+AR	-2447-06525	America/Argentina/Salta	(SA, LP, NQ, RN)
+AR	-2411-06518	America/Argentina/Jujuy	Jujuy (JY)
+AR	-2649-06513	America/Argentina/Tucuman	Tucumán (TM)
+AR	-2828-06547	America/Argentina/Catamarca	Catamarca (CT), Chubut (CH)
+AR	-2926-06651	America/Argentina/La_Rioja	La Rioja (LR)
+AR	-3132-06831	America/Argentina/San_Juan	San Juan (SJ)
+AR	-3253-06849	America/Argentina/Mendoza	Mendoza (MZ)
+AR	-3319-06621	America/Argentina/San_Luis	San Luis (SL)
+AR	-5138-06913	America/Argentina/Rio_Gallegos	Santa Cruz (SC)
+AR	-5448-06818	America/Argentina/Ushuaia	Tierra del Fuego (TF)
+AS,UM	-1416-17042	Pacific/Pago_Pago	Samoa, Midway
+AT	+4813+01620	Europe/Vienna
+AU	-3133+15905	Australia/Lord_Howe	Lord Howe Island
+AU	-5430+15857	Antarctica/Macquarie	Macquarie Island
+AU	-4253+14719	Australia/Hobart	Tasmania - most locations
+AU	-3956+14352	Australia/Currie	Tasmania - King Island
+AU	-3749+14458	Australia/Melbourne	Victoria
+AU	-3352+15113	Australia/Sydney	New South Wales - most locations
+AU	-3157+14127	Australia/Broken_Hill	New South Wales - Yancowinna
+AU	-2728+15302	Australia/Brisbane	Queensland - most locations
+AU	-2016+14900	Australia/Lindeman	Queensland - Holiday Islands
+AU	-3455+13835	Australia/Adelaide	South Australia
+AU	-1228+13050	Australia/Darwin	Northern Territory
+AU	-3157+11551	Australia/Perth	Western Australia - most locations
+AU	-3143+12852	Australia/Eucla	Western Australia - Eucla area
+AZ	+4023+04951	Asia/Baku
+BB	+1306-05937	America/Barbados
+BD	+2343+09025	Asia/Dhaka
+BE	+5050+00420	Europe/Brussels
+BG	+4241+02319	Europe/Sofia
+BM	+3217-06446	Atlantic/Bermuda
+BN	+0456+11455	Asia/Brunei
+BO	-1630-06809	America/La_Paz
+BR	-0351-03225	America/Noronha	Atlantic islands
+BR	-0127-04829	America/Belem	Amapá, E Pará
+BR	-0343-03830	America/Fortaleza	NE Brazil (MA, PI, CE, RN, PB)
+BR	-0803-03454	America/Recife	Pernambuco
+BR	-0712-04812	America/Araguaina	Tocantins
+BR	-0940-03543	America/Maceio	Alagoas, Sergipe
+BR	-1259-03831	America/Bahia	Bahia
+BR	-2332-04637	America/Sao_Paulo	S & SE Brazil (GO, DF, MG, ES, RJ, SP, PR, SC, RS)
+BR	-2027-05437	America/Campo_Grande	Mato Grosso do Sul
+BR	-1535-05605	America/Cuiaba	Mato Grosso
+BR	-0226-05452	America/Santarem	W Pará
+BR	-0846-06354	America/Porto_Velho	Rondônia
+BR	+0249-06040	America/Boa_Vista	Roraima
+BR	-0308-06001	America/Manaus	E Amazonas
+BR	-0640-06952	America/Eirunepe	W Amazonas
+BR	-0958-06748	America/Rio_Branco	Acre
+BS	+2505-07721	America/Nassau
+BT	+2728+08939	Asia/Thimphu
+BY	+5354+02734	Europe/Minsk
+BZ	+1730-08812	America/Belize
+CA	+4734-05243	America/St_Johns	Newfoundland Time, including SE Labrador
+CA	+4439-06336	America/Halifax	Atlantic Time - Nova Scotia (most places), PEI
+CA	+4612-05957	America/Glace_Bay	Atlantic Time - Nova Scotia - places that did not observe DST 1966-1971
+CA	+4606-06447	America/Moncton	Atlantic Time - New Brunswick
+CA	+5320-06025	America/Goose_Bay	Atlantic Time - Labrador - most locations
+CA	+5125-05707	America/Blanc-Sablon	Atlantic Standard Time - Quebec - Lower North Shore
+CA	+4339-07923	America/Toronto	Eastern Time - Ontario & Quebec - most locations
+CA	+4901-08816	America/Nipigon	Eastern Time - Ontario & Quebec - places that did not observe DST 1967-1973
+CA	+4823-08915	America/Thunder_Bay	Eastern Time - Thunder Bay, Ontario
+CA	+6344-06828	America/Iqaluit	Eastern Time - east Nunavut - most locations
+CA	+6608-06544	America/Pangnirtung	Eastern Time - Pangnirtung, Nunavut
+CA	+744144-0944945	America/Resolute	Central Time - Resolute, Nunavut
+CA	+484531-0913718	America/Atikokan	Eastern Standard Time - Atikokan, Ontario and Southampton I, Nunavut
+CA	+624900-0920459	America/Rankin_Inlet	Central Time - central Nunavut
+CA	+4953-09709	America/Winnipeg	Central Time - Manitoba & west Ontario
+CA	+4843-09434	America/Rainy_River	Central Time - Rainy River & Fort Frances, Ontario
+CA	+5024-10439	America/Regina	Central Standard Time - Saskatchewan - most locations
+CA	+5017-10750	America/Swift_Current	Central Standard Time - Saskatchewan - midwest
+CA	+5333-11328	America/Edmonton	Mountain Time - Alberta, east British Columbia & west Saskatchewan
+CA	+690650-1050310	America/Cambridge_Bay	Mountain Time - west Nunavut
+CA	+6227-11421	America/Yellowknife	Mountain Time - central Northwest Territories
+CA	+682059-1334300	America/Inuvik	Mountain Time - west Northwest Territories
+CA	+4906-11631	America/Creston	Mountain Standard Time - Creston, British Columbia
+CA	+5946-12014	America/Dawson_Creek	Mountain Standard Time - Dawson Creek & Fort Saint John, British Columbia
+CA	+4916-12307	America/Vancouver	Pacific Time - west British Columbia
+CA	+6043-13503	America/Whitehorse	Pacific Time - south Yukon
+CA	+6404-13925	America/Dawson	Pacific Time - north Yukon
+CC	-1210+09655	Indian/Cocos
+CH,DE,LI	+4723+00832	Europe/Zurich	Swiss time
+CI,BF,GM,GN,ML,MR,SH,SL,SN,ST,TG	+0519-00402	Africa/Abidjan
+CK	-2114-15946	Pacific/Rarotonga
+CL	-3327-07040	America/Santiago	most locations
+CL	-2709-10926	Pacific/Easter	Easter Island
+CN	+3114+12128	Asia/Shanghai	Beijing Time
+CN	+4348+08735	Asia/Urumqi	Xinjiang Time
+CO	+0436-07405	America/Bogota
+CR	+0956-08405	America/Costa_Rica
+CU	+2308-08222	America/Havana
+CV	+1455-02331	Atlantic/Cape_Verde
+CW,AW,BQ,SX	+1211-06900	America/Curacao
+CX	-1025+10543	Indian/Christmas
+CY	+3510+03322	Asia/Nicosia
+CZ,SK	+5005+01426	Europe/Prague
+DE	+5230+01322	Europe/Berlin	Berlin time
+DK	+5540+01235	Europe/Copenhagen
+DO	+1828-06954	America/Santo_Domingo
+DZ	+3647+00303	Africa/Algiers
+EC	-0210-07950	America/Guayaquil	mainland
+EC	-0054-08936	Pacific/Galapagos	Galápagos Islands
+EE	+5925+02445	Europe/Tallinn
+EG	+3003+03115	Africa/Cairo
+EH	+2709-01312	Africa/El_Aaiun
+ES	+4024-00341	Europe/Madrid	mainland
+ES	+3553-00519	Africa/Ceuta	Ceuta & Melilla
+ES	+2806-01524	Atlantic/Canary	Canary Islands
+FI,AX	+6010+02458	Europe/Helsinki
+FJ	-1808+17825	Pacific/Fiji
+FK	-5142-05751	Atlantic/Stanley
+FM	+0725+15147	Pacific/Chuuk	Chuuk (Truk) and Yap
+FM	+0658+15813	Pacific/Pohnpei	Pohnpei (Ponape)
+FM	+0519+16259	Pacific/Kosrae	Kosrae
+FO	+6201-00646	Atlantic/Faroe
+FR	+4852+00220	Europe/Paris
+GB,GG,IM,JE	+513030-0000731	Europe/London
+GE	+4143+04449	Asia/Tbilisi
+GF	+0456-05220	America/Cayenne
+GH	+0533-00013	Africa/Accra
+GI	+3608-00521	Europe/Gibraltar
+GL	+6411-05144	America/Godthab	most locations
+GL	+7646-01840	America/Danmarkshavn	east coast, north of Scoresbysund
+GL	+7029-02158	America/Scoresbysund	Scoresbysund / Ittoqqortoormiit
+GL	+7634-06847	America/Thule	Thule / Pituffik
+GR	+3758+02343	Europe/Athens
+GS	-5416-03632	Atlantic/South_Georgia
+GT	+1438-09031	America/Guatemala
+GU,MP	+1328+14445	Pacific/Guam
+GW	+1151-01535	Africa/Bissau
+GY	+0648-05810	America/Guyana
+HK	+2217+11409	Asia/Hong_Kong
+HN	+1406-08713	America/Tegucigalpa
+HT	+1832-07220	America/Port-au-Prince
+HU	+4730+01905	Europe/Budapest
+ID	-0610+10648	Asia/Jakarta	Java & Sumatra
+ID	-0002+10920	Asia/Pontianak	west & central Borneo
+ID	-0507+11924	Asia/Makassar	east & south Borneo, Sulawesi (Celebes), Bali, Nusa Tengarra, west Timor
+ID	-0232+14042	Asia/Jayapura	west New Guinea (Irian Jaya) & Malukus (Moluccas)
+IE	+5320-00615	Europe/Dublin
+IL	+314650+0351326	Asia/Jerusalem
+IN	+2232+08822	Asia/Kolkata
+IO	-0720+07225	Indian/Chagos
+IQ	+3321+04425	Asia/Baghdad
+IR	+3540+05126	Asia/Tehran
+IS	+6409-02151	Atlantic/Reykjavik
+IT,SM,VA	+4154+01229	Europe/Rome
+JM	+175805-0764736	America/Jamaica
+JO	+3157+03556	Asia/Amman
+JP	+353916+1394441	Asia/Tokyo
+KE,DJ,ER,ET,KM,MG,SO,TZ,UG,YT	-0117+03649	Africa/Nairobi
+KG	+4254+07436	Asia/Bishkek
+KI	+0125+17300	Pacific/Tarawa	Gilbert Islands
+KI	-0308-17105	Pacific/Enderbury	Phoenix Islands
+KI	+0152-15720	Pacific/Kiritimati	Line Islands
+KP	+3901+12545	Asia/Pyongyang
+KR	+3733+12658	Asia/Seoul
+KZ	+4315+07657	Asia/Almaty	most locations
+KZ	+4448+06528	Asia/Qyzylorda	Qyzylorda (Kyzylorda, Kzyl-Orda)
+KZ	+5017+05710	Asia/Aqtobe	Aqtobe (Aktobe)
+KZ	+4431+05016	Asia/Aqtau	Atyrau (Atirau, Gur'yev), Mangghystau (Mankistau)
+KZ	+5113+05121	Asia/Oral	West Kazakhstan
+LB	+3353+03530	Asia/Beirut
+LK	+0656+07951	Asia/Colombo
+LR	+0618-01047	Africa/Monrovia
+LT	+5441+02519	Europe/Vilnius
+LU	+4936+00609	Europe/Luxembourg
+LV	+5657+02406	Europe/Riga
+LY	+3254+01311	Africa/Tripoli
+MA	+3339-00735	Africa/Casablanca
+MC	+4342+00723	Europe/Monaco
+MD	+4700+02850	Europe/Chisinau
+MH	+0709+17112	Pacific/Majuro	most locations
+MH	+0905+16720	Pacific/Kwajalein	Kwajalein
+MM	+1647+09610	Asia/Rangoon
+MN	+4755+10653	Asia/Ulaanbaatar	most locations
+MN	+4801+09139	Asia/Hovd	Bayan-Ölgii, Govi-Altai, Hovd, Uvs, Zavkhan
+MN	+4804+11430	Asia/Choibalsan	Dornod, Sükhbaatar
+MO	+2214+11335	Asia/Macau
+MQ	+1436-06105	America/Martinique
+MT	+3554+01431	Europe/Malta
+MU	-2010+05730	Indian/Mauritius
+MV	+0410+07330	Indian/Maldives
+MX	+1924-09909	America/Mexico_City	Central Time - most locations
+MX	+2105-08646	America/Cancun	Eastern Standard Time - Quintana Roo
+MX	+2058-08937	America/Merida	Central Time - Campeche, Yucatán
+MX	+2540-10019	America/Monterrey	Mexican Central Time - Coahuila, Durango, Nuevo León, Tamaulipas away from US border
+MX	+2550-09730	America/Matamoros	US Central Time - Coahuila, Durango, Nuevo León, Tamaulipas near US border
+MX	+2313-10625	America/Mazatlan	Mountain Time - S Baja, Nayarit, Sinaloa
+MX	+2838-10605	America/Chihuahua	Mexican Mountain Time - Chihuahua away from US border
+MX	+2934-10425	America/Ojinaga	US Mountain Time - Chihuahua near US border
+MX	+2904-11058	America/Hermosillo	Mountain Standard Time - Sonora
+MX	+3232-11701	America/Tijuana	US Pacific Time - Baja California near US border
+MX	+3018-11452	America/Santa_Isabel	Mexican Pacific Time - Baja California away from US border
+MX	+2048-10515	America/Bahia_Banderas	Mexican Central Time - Bahía de Banderas
+MY	+0310+10142	Asia/Kuala_Lumpur	peninsular Malaysia
+MY	+0133+11020	Asia/Kuching	Sabah & Sarawak
+MZ,BI,BW,CD,MW,RW,ZM,ZW	-2558+03235	Africa/Maputo	Central Africa Time (UTC+2)
+NA	-2234+01706	Africa/Windhoek
+NC	-2216+16627	Pacific/Noumea
+NF	-2903+16758	Pacific/Norfolk
+NG,AO,BJ,CD,CF,CG,CM,GA,GQ,NE	+0627+00324	Africa/Lagos	West Africa Time (UTC+1)
+NI	+1209-08617	America/Managua
+NL	+5222+00454	Europe/Amsterdam
+NO,SJ	+5955+01045	Europe/Oslo
+NP	+2743+08519	Asia/Kathmandu
+NR	-0031+16655	Pacific/Nauru
+NU	-1901-16955	Pacific/Niue
+NZ,AQ	-3652+17446	Pacific/Auckland	New Zealand time
+NZ	-4357-17633	Pacific/Chatham	Chatham Islands
+PA,KY	+0858-07932	America/Panama
+PE	-1203-07703	America/Lima
+PF	-1732-14934	Pacific/Tahiti	Society Islands
+PF	-0900-13930	Pacific/Marquesas	Marquesas Islands
+PF	-2308-13457	Pacific/Gambier	Gambier Islands
+PG	-0930+14710	Pacific/Port_Moresby	most locations
+PG	-0613+15534	Pacific/Bougainville	Bougainville
+PH	+1435+12100	Asia/Manila
+PK	+2452+06703	Asia/Karachi
+PL	+5215+02100	Europe/Warsaw
+PM	+4703-05620	America/Miquelon
+PN	-2504-13005	Pacific/Pitcairn
+PR	+182806-0660622	America/Puerto_Rico
+PS	+3130+03428	Asia/Gaza	Gaza Strip
+PS	+313200+0350542	Asia/Hebron	West Bank
+PT	+3843-00908	Europe/Lisbon	mainland
+PT	+3238-01654	Atlantic/Madeira	Madeira Islands
+PT	+3744-02540	Atlantic/Azores	Azores
+PW	+0720+13429	Pacific/Palau
+PY	-2516-05740	America/Asuncion
+QA,BH	+2517+05132	Asia/Qatar
+RE,TF	-2052+05528	Indian/Reunion	Réunion, Crozet Is, Scattered Is
+RO	+4426+02606	Europe/Bucharest
+RS,BA,HR,ME,MK,SI	+4450+02030	Europe/Belgrade
+RU	+5443+02030	Europe/Kaliningrad	Moscow-01 - Kaliningrad
+RU	+554521+0373704	Europe/Moscow	Moscow+00 - west Russia
+RU	+4457+03406	Europe/Simferopol	Moscow+00 - Crimea
+RU	+4844+04425	Europe/Volgograd	Moscow+00 - Caspian Sea
+RU	+5312+05009	Europe/Samara	Moscow+00 (Moscow+01 after 2014-10-26) - Samara, Udmurtia
+RU	+5651+06036	Asia/Yekaterinburg	Moscow+02 - Urals
+RU	+5500+07324	Asia/Omsk	Moscow+03 - west Siberia
+RU	+5502+08255	Asia/Novosibirsk	Moscow+03 - Novosibirsk
+RU	+5345+08707	Asia/Novokuznetsk	Moscow+03 (Moscow+04 after 2014-10-26) - Kemerovo
+RU	+5601+09250	Asia/Krasnoyarsk	Moscow+04 - Yenisei River
+RU	+5216+10420	Asia/Irkutsk	Moscow+05 - Lake Baikal
+RU	+5203+11328	Asia/Chita	Moscow+06 (Moscow+05 after 2014-10-26) - Zabaykalsky
+RU	+6200+12940	Asia/Yakutsk	Moscow+06 - Lena River
+RU	+623923+1353314	Asia/Khandyga	Moscow+06 - Tomponsky, Ust-Maysky
+RU	+4310+13156	Asia/Vladivostok	Moscow+07 - Amur River
+RU	+4658+14242	Asia/Sakhalin	Moscow+07 - Sakhalin Island
+RU	+643337+1431336	Asia/Ust-Nera	Moscow+07 - Oymyakonsky
+RU	+5934+15048	Asia/Magadan	Moscow+08 (Moscow+07 after 2014-10-26) - Magadan
+RU	+6728+15343	Asia/Srednekolymsk	Moscow+08 - E Sakha, N Kuril Is
+RU	+5301+15839	Asia/Kamchatka	Moscow+08 (Moscow+09 after 2014-10-26) - Kamchatka
+RU	+6445+17729	Asia/Anadyr	Moscow+08 (Moscow+09 after 2014-10-26) - Bering Sea
+SA,KW,YE	+2438+04643	Asia/Riyadh
+SB	-0932+16012	Pacific/Guadalcanal
+SC	-0440+05528	Indian/Mahe
+SD,SS	+1536+03232	Africa/Khartoum
+SE	+5920+01803	Europe/Stockholm
+SG	+0117+10351	Asia/Singapore
+SR	+0550-05510	America/Paramaribo
+SV	+1342-08912	America/El_Salvador
+SY	+3330+03618	Asia/Damascus
+TC	+2128-07108	America/Grand_Turk
+TD	+1207+01503	Africa/Ndjamena
+TF	-492110+0701303	Indian/Kerguelen	Kerguelen, St Paul I, Amsterdam I
+TH,KH,LA,VN	+1345+10031	Asia/Bangkok	most of Indochina
+TJ	+3835+06848	Asia/Dushanbe
+TK	-0922-17114	Pacific/Fakaofo
+TL	-0833+12535	Asia/Dili
+TM	+3757+05823	Asia/Ashgabat
+TN	+3648+01011	Africa/Tunis
+TO	-2110-17510	Pacific/Tongatapu
+TR	+4101+02858	Europe/Istanbul
+TT,AG,AI,BL,DM,GD,GP,KN,LC,MF,MS,VC,VG,VI	+1039-06131	America/Port_of_Spain
+TV	-0831+17913	Pacific/Funafuti
+TW	+2503+12130	Asia/Taipei
+UA	+5026+03031	Europe/Kiev	most locations
+UA	+4837+02218	Europe/Uzhgorod	Ruthenia
+UA	+4750+03510	Europe/Zaporozhye	Zaporozh'ye, E Lugansk / Zaporizhia, E Luhansk
+UM	+1917+16637	Pacific/Wake	Wake Island
+US	+404251-0740023	America/New_York	Eastern Time
+US	+421953-0830245	America/Detroit	Eastern Time - Michigan - most locations
+US	+381515-0854534	America/Kentucky/Louisville	Eastern Time - Kentucky - Louisville area
+US	+364947-0845057	America/Kentucky/Monticello	Eastern Time - Kentucky - Wayne County
+US	+394606-0860929	America/Indiana/Indianapolis	Eastern Time - Indiana - most locations
+US	+384038-0873143	America/Indiana/Vincennes	Eastern Time - Indiana - Daviess, Dubois, Knox & Martin Counties
+US	+410305-0863611	America/Indiana/Winamac	Eastern Time - Indiana - Pulaski County
+US	+382232-0862041	America/Indiana/Marengo	Eastern Time - Indiana - Crawford County
+US	+382931-0871643	America/Indiana/Petersburg	Eastern Time - Indiana - Pike County
+US	+384452-0850402	America/Indiana/Vevay	Eastern Time - Indiana - Switzerland County
+US	+415100-0873900	America/Chicago	Central Time
+US	+375711-0864541	America/Indiana/Tell_City	Central Time - Indiana - Perry County
+US	+411745-0863730	America/Indiana/Knox	Central Time - Indiana - Starke County
+US	+450628-0873651	America/Menominee	Central Time - Michigan - Dickinson, Gogebic, Iron & Menominee Counties
+US	+470659-1011757	America/North_Dakota/Center	Central Time - North Dakota - Oliver County
+US	+465042-1012439	America/North_Dakota/New_Salem	Central Time - North Dakota - Morton County (except Mandan area)
+US	+471551-1014640	America/North_Dakota/Beulah	Central Time - North Dakota - Mercer County
+US	+394421-1045903	America/Denver	Mountain Time
+US	+433649-1161209	America/Boise	Mountain Time - south Idaho & east Oregon
+US	+332654-1120424	America/Phoenix	Mountain Standard Time - Arizona (except Navajo)
+US	+340308-1181434	America/Los_Angeles	Pacific Time
+US	+550737-1313435	America/Metlakatla	Pacific Standard Time - Annette Island, Alaska
+US	+611305-1495401	America/Anchorage	Alaska Time
+US	+581807-1342511	America/Juneau	Alaska Time - Alaska panhandle
+US	+571035-1351807	America/Sitka	Alaska Time - southeast Alaska panhandle
+US	+593249-1394338	America/Yakutat	Alaska Time - Alaska panhandle neck
+US	+643004-1652423	America/Nome	Alaska Time - west Alaska
+US	+515248-1763929	America/Adak	Aleutian Islands
+US,UM	+211825-1575130	Pacific/Honolulu	Hawaii time
+UY	-3453-05611	America/Montevideo
+UZ	+3940+06648	Asia/Samarkand	west Uzbekistan
+UZ	+4120+06918	Asia/Tashkent	east Uzbekistan
+VE	+1030-06656	America/Caracas
+VN	+1045+10640	Asia/Ho_Chi_Minh	south Vietnam
+VU	-1740+16825	Pacific/Efate
+WF	-1318-17610	Pacific/Wallis
+WS	-1350-17144	Pacific/Apia
+ZA,LS,SZ	-2615+02800	Africa/Johannesburg

--- a/src/test/java/org/joda/time/TestDateTimeZone.java
+++ b/src/test/java/org/joda/time/TestDateTimeZone.java
@@ -664,7 +664,7 @@ public class TestDateTimeZone extends TestCase {
 
     //-----------------------------------------------------------------------
     public void testConstructor() {
-        assertEquals(1, DateTimeZone.class.getDeclaredConstructors().length);
+        assertEquals(2, DateTimeZone.class.getDeclaredConstructors().length);
         assertTrue(Modifier.isProtected(DateTimeZone.class.getDeclaredConstructors()[0].getModifiers()));
         try {
             new DateTimeZone(null) {

--- a/src/test/java/org/joda/time/tz/TestAll.java
+++ b/src/test/java/org/joda/time/tz/TestAll.java
@@ -39,6 +39,7 @@ public class TestAll extends TestCase {
         suite.addTest(TestCompiler.suite());
         suite.addTest(TestCachedDateTimeZone.suite());
         suite.addTest(TestFixedDateTimeZone.suite());
+        suite.addTest(TestTimeZoneCountries.suite());
         return suite;
     }
 

--- a/src/test/java/org/joda/time/tz/TestTimeZoneCountries.java
+++ b/src/test/java/org/joda/time/tz/TestTimeZoneCountries.java
@@ -1,0 +1,36 @@
+package org.joda.time.tz;
+
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Set;
+
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+import org.joda.time.DateTimeZone;
+
+public class TestTimeZoneCountries extends TestCase{
+	
+    public static void main(String[] args) {
+        junit.textui.TestRunner.run(suite());
+    }
+
+    public static TestSuite suite() {
+        return new TestSuite(TestTimeZoneCountries.class);
+    }
+
+    public TestTimeZoneCountries(String name) {
+        super(name);
+    }
+
+    public void testTimeZoneCountry() throws Exception {
+    	DateTimeZone dt = DateTimeZone.forID("US/Pacific");
+    	HashMap<String, String> countries = dt.getLocationInfo().getCountries();
+    	Set<String> countryCodes = countries.keySet();
+    	
+        assertEquals("America/Los_Angeles", dt.getID());
+        assertEquals("United States", countries.get(countryCodes.iterator().next()));
+    }
+
+}


### PR DESCRIPTION
This commit fixes #255.

I've made changes to parse the location info from the tz data files and store it in the current zone info files while taking care that none of the existing functionality breaks.
While there is no explicit mapping from country to timezones, the same can be obtained by iterating over the available IDs and then getting the location-info(countries, latitude, longitude) for each of the timezones.

Have included the required 3 data files from IANA in the tz data.