### PR TITLE
Fix for: #288 Is time zone printing broken for upcoming JDK 1.8u60?

### DIFF
--- a/src/main/java/org/joda/time/tz/DefaultNameProvider.java
+++ b/src/main/java/org/joda/time/tz/DefaultNameProvider.java
@@ -15,12 +15,12 @@
  */
 package org.joda.time.tz;
 
+import org.joda.time.DateTimeUtils;
+
 import java.text.DateFormatSymbols;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-
-import org.joda.time.DateTimeUtils;
 
 /**
  * The default name provider acquires localized names from
@@ -47,7 +47,7 @@ public class DefaultNameProvider implements NameProvider {
         String[] nameSet = getNameSet(locale, id, nameKey);
         return nameSet == null ? null : nameSet[0];
     }
-    
+
     public String getName(Locale locale, String id, String nameKey) {
         String[] nameSet = getNameSet(locale, id, nameKey);
         return nameSet == null ? null : nameSet[1];
@@ -66,34 +66,34 @@ public class DefaultNameProvider implements NameProvider {
         Map<String, Object> byNameKeyCache = byIdCache.get(id);
         if (byNameKeyCache == null) {
             byIdCache.put(id, byNameKeyCache = createCache());
-            
+
             String[][] zoneStringsEn = DateTimeUtils.getDateFormatSymbols(Locale.ENGLISH).getZoneStrings();
             String[] setEn = null;
             for (String[] strings : zoneStringsEn) {
-              if (strings != null && strings.length == 5 && id.equals(strings[0])) {
-                setEn = strings;
-                break;
-              }
+                if (strings != null && (strings.length == 5 || strings.length == 7) && id.equals(strings[0])) {
+                    setEn = strings;
+                    break;
+                }
             }
             String[][] zoneStringsLoc = DateTimeUtils.getDateFormatSymbols(locale).getZoneStrings();
             String[] setLoc = null;
             for (String[] strings : zoneStringsLoc) {
-              if (strings != null && strings.length == 5 && id.equals(strings[0])) {
-                setLoc = strings;
-                break;
-              }
+                if (strings != null && (strings.length == 5 || strings.length == 7) && id.equals(strings[0])) {
+                    setLoc = strings;
+                    break;
+                }
             }
-            
+
             if (setEn != null && setLoc != null) {
-              byNameKeyCache.put(setEn[2], new String[] {setLoc[2], setLoc[1]});
-              // need to handle case where summer and winter have the same
-              // abbreviation, such as EST in Australia [1716305]
-              // we handle this by appending "-Summer", cf ZoneInfoCompiler
-              if (setEn[2].equals(setEn[4])) {
-                  byNameKeyCache.put(setEn[4] + "-Summer", new String[] {setLoc[4], setLoc[3]});
-              } else {
-                  byNameKeyCache.put(setEn[4], new String[] {setLoc[4], setLoc[3]});
-              }
+                byNameKeyCache.put(setEn[2], new String[]{setLoc[2], setLoc[1]});
+                // need to handle case where summer and winter have the same
+                // abbreviation, such as EST in Australia [1716305]
+                // we handle this by appending "-Summer", cf ZoneInfoCompiler
+                if (setEn[2].equals(setEn[4])) {
+                    byNameKeyCache.put(setEn[4] + "-Summer", new String[]{setLoc[4], setLoc[3]});
+                } else {
+                    byNameKeyCache.put(setEn[4], new String[]{setLoc[4], setLoc[3]});
+                }
             }
         }
         return (String[]) byNameKeyCache.get(nameKey);
@@ -106,7 +106,7 @@ public class DefaultNameProvider implements NameProvider {
         String[] nameSet = getNameSet(locale, id, nameKey, standardTime);
         return nameSet == null ? null : nameSet[0];
     }
-    
+
     public String getName(Locale locale, String id, String nameKey, boolean standardTime) {
         String[] nameSet = getNameSet(locale, id, nameKey, standardTime);
         return nameSet == null ? null : nameSet[1];
@@ -128,27 +128,27 @@ public class DefaultNameProvider implements NameProvider {
         Map<Boolean, Object> byNameKeyCache = byIdCache.get(id);
         if (byNameKeyCache == null) {
             byIdCache.put(id, byNameKeyCache = createCache());
-            
+
             String[][] zoneStringsEn = DateTimeUtils.getDateFormatSymbols(Locale.ENGLISH).getZoneStrings();
             String[] setEn = null;
             for (String[] strings : zoneStringsEn) {
-              if (strings != null && strings.length == 5 && id.equals(strings[0])) {
-                setEn = strings;
-                break;
-              }
+                if (strings != null && (strings.length == 5 || strings.length == 7) && id.equals(strings[0])) {
+                    setEn = strings;
+                    break;
+                }
             }
             String[][] zoneStringsLoc = DateTimeUtils.getDateFormatSymbols(locale).getZoneStrings();
             String[] setLoc = null;
             for (String[] strings : zoneStringsLoc) {
-              if (strings != null && strings.length == 5 && id.equals(strings[0])) {
-                setLoc = strings;
-                break;
-              }
+                if (strings != null && (strings.length == 5 || strings.length == 7) && id.equals(strings[0])) {
+                    setLoc = strings;
+                    break;
+                }
             }
-            
+
             if (setEn != null && setLoc != null) {
-              byNameKeyCache.put(Boolean.TRUE, new String[] {setLoc[2], setLoc[1]});
-              byNameKeyCache.put(Boolean.FALSE, new String[] {setLoc[4], setLoc[3]});
+                byNameKeyCache.put(Boolean.TRUE, new String[]{setLoc[2], setLoc[1]});
+                byNameKeyCache.put(Boolean.FALSE, new String[]{setLoc[4], setLoc[3]});
             }
         }
         return (String[]) byNameKeyCache.get(Boolean.valueOf(standardTime));


### PR DESCRIPTION
Since Java 1.8u60 (see https://bugs.openjdk.java.net/browse/JDK-8076287) DateTimeUtils will return String array containing arrays with seven strings instead of five. First five elements are same across versions. This change will accept both array sizes as we are interested in first five elements.