### PR TITLE
Fixes typo. s/exract/extract/

### DIFF
--- a/src/main/java/org/joda/time/ReadableInterval.java
+++ b/src/main/java/org/joda/time/ReadableInterval.java
@@ -260,7 +260,7 @@ public interface ReadableInterval {
      * Converts the duration of the interval to a period using the
      * standard period type.
      * <p>
-     * This method should be used to exract the field values describing the
+     * This method should be used to extract the field values describing the
      * difference between the start and end instants.
      *
      * @return a time period derived from the interval
@@ -271,7 +271,7 @@ public interface ReadableInterval {
      * Converts the duration of the interval to a period using the
      * specified period type.
      * <p>
-     * This method should be used to exract the field values describing the
+     * This method should be used to extract the field values describing the
      * difference between the start and end instants.
      *
      * @param type  the requested type of the duration, null means standard

--- a/src/main/java/org/joda/time/base/AbstractInterval.java
+++ b/src/main/java/org/joda/time/base/AbstractInterval.java
@@ -424,7 +424,7 @@ public abstract class AbstractInterval implements ReadableInterval {
      * Converts the duration of the interval to a <code>Period</code> using the
      * All period type.
      * <p>
-     * This method should be used to exract the field values describing the
+     * This method should be used to extract the field values describing the
      * difference between the start and end instants.
      *
      * @return a time period derived from the interval
@@ -437,7 +437,7 @@ public abstract class AbstractInterval implements ReadableInterval {
      * Converts the duration of the interval to a <code>Period</code> using the
      * specified period type.
      * <p>
-     * This method should be used to exract the field values describing the
+     * This method should be used to extract the field values describing the
      * difference between the start and end instants.
      *
      * @param type  the requested type of the duration, null means AllType


### PR DESCRIPTION
Fixes a typo I ran across earlier today.

`mvn clean install` ran successfully.