### PR TITLE
Overflow bug fix and documentation fix

### DIFF
--- a/src/main/java/org/joda/time/Interval.java
+++ b/src/main/java/org/joda/time/Interval.java
@@ -462,7 +462,7 @@ public final class Interval
     }
 
     /**
-     * Creates a new interval with the specified start millisecond instant.
+     * Creates a new interval with the specified end millisecond instant.
      *
      * @param endInstant  the end instant for the new interval
      * @return an interval with the start from this interval and the specified end

--- a/src/main/java/org/joda/time/base/AbstractInterval.java
+++ b/src/main/java/org/joda/time/base/AbstractInterval.java
@@ -399,7 +399,7 @@ public abstract class AbstractInterval implements ReadableInterval {
      * @throws ArithmeticException if the duration exceeds the capacity of a long
      */
     public long toDurationMillis() {
-        return FieldUtils.safeAdd(getEndMillis(), -getStartMillis());
+        return FieldUtils.safeSubtract(getEndMillis(), getStartMillis());
     }
 
     /**


### PR DESCRIPTION
Fixed bug with overflow in org/joda/time/base/AbstractInterval.toDurationMillis method (if getStartMillis() == Long.MIN_VALUE negating causes uncaught overflow).
Corrected mistake in documentation of org/joda/time/Interval.withEndMillis method.