### PR TITLE
ZoneInfoCompiler does not check validity of input file

### DIFF
--- a/src/main/java/org/joda/time/tz/ZoneInfoCompiler.java
+++ b/src/main/java/org/joda/time/tz/ZoneInfoCompiler.java
@@ -694,6 +694,9 @@ public class ZoneInfoCompiler {
         public final String iLetterS;
 
         Rule(StringTokenizer st) {
+            if (st.countTokens() < 6) {
+                throw new IllegalArgumentException("Attempting to create a Rule from an incomplete tokenizer");
+            }
             iName = st.nextToken().intern();
             iFromYear = parseYear(st.nextToken(), 0);
             iToYear = parseYear(st.nextToken(), iFromYear);


### PR DESCRIPTION
The Rule constructor in org.joda.time.tz.ZoneInfoCompiler.java does not
check the number of elements in the StringTokenier obtained from parsing
the timezone file.  There is an assumption that the input TimeZone file
will always be valid, leading to runtime exceptions with no good error
message when the file is invalid. This pull request adds a potential fix
and a test for this issue. 