### PR TITLE
fixes bug in timezone resolution that prevents some timezones being resolved

### DIFF
--- a/src/main/java/org/joda/time/format/DateTimeFormatterBuilder.java
+++ b/src/main/java/org/joda/time/format/DateTimeFormatterBuilder.java
@@ -2618,14 +2618,16 @@ public class DateTimeFormatterBuilder {
     }
 
     static int csCompare(CharSequence text, int position, String search) {
-        int compareLen = Math.min(text.length() - position, search.length());
+        int matchLen = text.length() - position;
+        int searchLen = search.length();
+        int compareLen = Math.min(matchLen, searchLen);
         for (int i = 0; i < compareLen; i++) {
             int result = search.charAt(i) - text.charAt(position + i);
             if (result != 0) {
                 return result;
             }
         }
-        return 0;
+        return searchLen - matchLen;
     }
 
     static boolean csStartsWith(CharSequence text, int position, String search) {

--- a/src/test/java/org/joda/time/format/TestDateTimeFormatterBuilder.java
+++ b/src/test/java/org/joda/time/format/TestDateTimeFormatterBuilder.java
@@ -435,6 +435,26 @@ public class TestDateTimeFormatterBuilder extends TestCase {
         assertEquals(dt, f.parseDateTime("2007-03-04 12:30 America/Dawson_Creek"));
     }
 
+    public void test_printParseZoneEtcGMT() {
+        DateTimeFormatterBuilder bld = new DateTimeFormatterBuilder()
+                .appendPattern("yyyy-MM-dd HH:mm ZZZ");
+        DateTimeFormatter f = bld.toFormatter();
+
+        DateTime dt = new DateTime(2007, 3, 4, 12, 30, 0, DateTimeZone.forID("Etc/GMT"));
+        assertEquals("2007-03-04 12:30 Etc/GMT", f.print(dt));
+        assertEquals(dt, f.parseDateTime("2007-03-04 12:30 Etc/GMT"));
+    }
+
+    public void test_printParseZoneEtcGMT1() {
+        DateTimeFormatterBuilder bld = new DateTimeFormatterBuilder()
+                .appendPattern("yyyy-MM-dd HH:mm ZZZ");
+        DateTimeFormatter f = bld.toFormatter();
+
+        DateTime dt = new DateTime(2007, 3, 4, 12, 30, 0, DateTimeZone.forID("Etc/GMT+1"));
+        assertEquals("2007-03-04 12:30 Etc/GMT+1", f.print(dt));
+        assertEquals(dt, f.parseDateTime("2007-03-04 12:30 Etc/GMT+1"));
+    }
+
     public void test_printParseZoneBahiaBanderas() {
         DateTimeFormatterBuilder bld = new DateTimeFormatterBuilder()
             .appendPattern("yyyy-MM-dd HH:mm ").appendTimeZoneId();


### PR DESCRIPTION
@jodastephen https://github.com/JodaOrg/joda-time/commit/027bfdde0338f53fc0f20a18a447c52a3f7e02cd introduced a subtle timezone parsing bug into 2.9.x - the binary search implementation doesn't pivot on string length correctly. The material result is that some shorter timezone names won't resolve if there are names in the timezone list that contain the shorter name as a prefix. We encountered this with the timezone `"Etc/GMT"` failing to parse when we upgraded to 2.9.1. This has forced us to rollback to 2.8.2 pending a fix. 

