### PR TITLE
ZoneInfoCompiler$Zone does not check validity of input file

### DIFF
--- a/src/main/java/org/joda/time/tz/ZoneInfoCompiler.java
+++ b/src/main/java/org/joda/time/tz/ZoneInfoCompiler.java
@@ -528,6 +528,9 @@ public class ZoneInfoCompiler {
                         rs.addRule(r);
                     }
                 } else if (token.equalsIgnoreCase("Zone")) {
+		    if (st.countTokens() < 4) {
+			throw new IllegalArgumentException("Attempting to create a Zone from an incomplete tokenizer");
+		    }
                     zone = new Zone(st);
                 } else if (token.equalsIgnoreCase("Link")) {
                     String real = st.nextToken();

--- a/src/test/java/org/joda/time/tz/TestCompiler.java
+++ b/src/test/java/org/joda/time/tz/TestCompiler.java
@@ -76,6 +76,14 @@ public class TestCompiler extends TestCase {
         "Rule    US  1918    1919    -   Mar lastSun 2:00    1:00    D\n" +
         "Rule    \n" ; // this line is intentionally incomplete
 
+    static final String BROKEN_TIMEZONE_FILE_2 =
+	"# Incomplete Zone for building America/Los_Angeles time zone.\n" +
+	"\n" +
+	"Rule    CA  1948    only    -   Mar 14  2:00    1:00    D\n" +
+	"Rule    CA  1949    only    -   Jan  1  2:00    0   S\n" +
+	"\n" +
+	"Zone "; // this line is intentionally left incomplete
+
     private DateTimeZone originalDateTimeZone = null;
 
     public TestCompiler(String name) {
@@ -135,6 +143,17 @@ public class TestCompiler extends TestCase {
         } catch(IllegalArgumentException iae) {
             assertEquals("Attempting to create a Rule from an incomplete tokenizer", iae.getMessage());
         }
+    }
+    public void testCompileOnBrokenTimeZoneFile_2() throws Exception {
+	try {
+	    Provider provider = compileAndLoad(BROKEN_TIMEZONE_FILE_2);
+	    fail();
+	} catch(NoSuchElementException nsee) {
+	    // This thrown from the Zone constructor
+	    fail("NoSuchElementException was thrown; broken timezone file?");
+	} catch(IllegalArgumentException iae) {
+	    assertEquals("Attempting to create a Zone from an incomplete tokenizer", iae.getMessage());
+	}
     }
 
     private Provider compileAndLoad(String data) throws Exception {


### PR DESCRIPTION
In org.joda.time.tz.ZoneInfoCompiler.java, the number of elements in the StringTokenier obtained from parsing the timezone file is not checked. There is an assumption that the input TimeZone file
will always be valid, leading to runtime exceptions with no good error message when the file is invalid. This pull request adds a potential fix and a test for this issue.