### PR TITLE
Closing ObjectOutputStream before calling toByteArray on the underlying ByteArrayOutputStream

### DIFF
--- a/src/test/java/org/joda/time/TestDateMidnight_Basics.java
+++ b/src/test/java/org/joda/time/TestDateMidnight_Basics.java
@@ -422,8 +422,8 @@ public class TestDateMidnight_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestDateTimeComparator.java
+++ b/src/test/java/org/joda/time/TestDateTimeComparator.java
@@ -271,8 +271,8 @@ public class TestDateTimeComparator extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(c);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);
@@ -289,8 +289,8 @@ public class TestDateTimeComparator extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(c);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestDateTimeFieldType.java
+++ b/src/test/java/org/joda/time/TestDateTimeFieldType.java
@@ -314,8 +314,8 @@ public class TestDateTimeFieldType extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(type);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestDateTimeZone.java
+++ b/src/test/java/org/joda/time/TestDateTimeZone.java
@@ -1025,8 +1025,8 @@ public class TestDateTimeZone extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(zone);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);
@@ -1043,8 +1043,8 @@ public class TestDateTimeZone extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(zone);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestDateTime_Basics.java
+++ b/src/test/java/org/joda/time/TestDateTime_Basics.java
@@ -487,8 +487,8 @@ public class TestDateTime_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestDays.java
+++ b/src/test/java/org/joda/time/TestDays.java
@@ -240,8 +240,8 @@ public class TestDays extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestDurationFieldType.java
+++ b/src/test/java/org/joda/time/TestDurationFieldType.java
@@ -176,8 +176,8 @@ public class TestDurationFieldType extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(type);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestDuration_Basics.java
+++ b/src/test/java/org/joda/time/TestDuration_Basics.java
@@ -237,8 +237,8 @@ public class TestDuration_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestHours.java
+++ b/src/test/java/org/joda/time/TestHours.java
@@ -209,8 +209,8 @@ public class TestHours extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestInstant_Basics.java
+++ b/src/test/java/org/joda/time/TestInstant_Basics.java
@@ -367,8 +367,8 @@ public class TestInstant_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestInterval_Basics.java
+++ b/src/test/java/org/joda/time/TestInterval_Basics.java
@@ -1032,8 +1032,8 @@ public class TestInterval_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestLocalDateTime_Basics.java
+++ b/src/test/java/org/joda/time/TestLocalDateTime_Basics.java
@@ -1051,8 +1051,8 @@ public class TestLocalDateTime_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestLocalDate_Basics.java
+++ b/src/test/java/org/joda/time/TestLocalDate_Basics.java
@@ -1106,8 +1106,8 @@ public class TestLocalDate_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestLocalTime_Basics.java
+++ b/src/test/java/org/joda/time/TestLocalTime_Basics.java
@@ -766,8 +766,8 @@ public class TestLocalTime_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestMinutes.java
+++ b/src/test/java/org/joda/time/TestMinutes.java
@@ -199,8 +199,8 @@ public class TestMinutes extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestMonthDay_Basics.java
+++ b/src/test/java/org/joda/time/TestMonthDay_Basics.java
@@ -769,8 +769,8 @@ public class TestMonthDay_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestMonths.java
+++ b/src/test/java/org/joda/time/TestMonths.java
@@ -226,8 +226,8 @@ public class TestMonths extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestMutableDateTime_Basics.java
+++ b/src/test/java/org/joda/time/TestMutableDateTime_Basics.java
@@ -391,8 +391,8 @@ public class TestMutableDateTime_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestMutableInterval_Basics.java
+++ b/src/test/java/org/joda/time/TestMutableInterval_Basics.java
@@ -452,8 +452,8 @@ public class TestMutableInterval_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestMutablePeriod_Basics.java
+++ b/src/test/java/org/joda/time/TestMutablePeriod_Basics.java
@@ -163,8 +163,8 @@ public class TestMutablePeriod_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestPartial_Basics.java
+++ b/src/test/java/org/joda/time/TestPartial_Basics.java
@@ -781,8 +781,8 @@ public class TestPartial_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestPeriodType.java
+++ b/src/test/java/org/joda/time/TestPeriodType.java
@@ -110,8 +110,8 @@ public class TestPeriodType extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(type);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);
@@ -125,8 +125,8 @@ public class TestPeriodType extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(type);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestPeriod_Basics.java
+++ b/src/test/java/org/joda/time/TestPeriod_Basics.java
@@ -230,8 +230,8 @@ public class TestPeriod_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestSeconds.java
+++ b/src/test/java/org/joda/time/TestSeconds.java
@@ -196,8 +196,8 @@ public class TestSeconds extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestTimeOfDay_Basics.java
+++ b/src/test/java/org/joda/time/TestTimeOfDay_Basics.java
@@ -853,8 +853,8 @@ public class TestTimeOfDay_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestWeeks.java
+++ b/src/test/java/org/joda/time/TestWeeks.java
@@ -198,8 +198,8 @@ public class TestWeeks extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestYearMonthDay_Basics.java
+++ b/src/test/java/org/joda/time/TestYearMonthDay_Basics.java
@@ -779,8 +779,8 @@ public class TestYearMonthDay_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestYearMonth_Basics.java
+++ b/src/test/java/org/joda/time/TestYearMonth_Basics.java
@@ -603,8 +603,8 @@ public class TestYearMonth_Basics extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/TestYears.java
+++ b/src/test/java/org/joda/time/TestYears.java
@@ -181,8 +181,8 @@ public class TestYears extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/field/TestMillisDurationField.java
+++ b/src/test/java/org/joda/time/field/TestMillisDurationField.java
@@ -202,8 +202,8 @@ public class TestMillisDurationField extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/field/TestPreciseDurationField.java
+++ b/src/test/java/org/joda/time/field/TestPreciseDurationField.java
@@ -261,8 +261,8 @@ public class TestPreciseDurationField extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/field/TestScaledDurationField.java
+++ b/src/test/java/org/joda/time/field/TestScaledDurationField.java
@@ -278,8 +278,8 @@ public class TestScaledDurationField extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);

--- a/src/test/java/org/joda/time/tz/TestCachedDateTimeZone.java
+++ b/src/test/java/org/joda/time/tz/TestCachedDateTimeZone.java
@@ -68,8 +68,8 @@ public class TestCachedDateTimeZone extends TestCase {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
-        byte[] bytes = baos.toByteArray();
         oos.close();
+        byte[] bytes = baos.toByteArray();
         
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);


### PR DESCRIPTION
 When an ObjectOutputStream instance wraps an underlying ByteArrayOutputStream instance,
  it is recommended to flush or close the ObjectOutputStream before invoking the underlying instances's toByteArray().
Although in these cases this is not strictly necessary because the
writeObject method is invoked right before toByteArray, and writeObject
internally calls flush/drain.  However, it is a good practice to call
flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request flips the order of close and toytBeArray methods.
While there are seemingly many changes, they're all just copies of
the same change.  Please let me know if you want me to extract the
common code into one helper method.