### PR TITLE
Provide useful error log when no zone info provider is available

### DIFF
--- a/src/main/java/org/joda/time/DateTimeZone.java
+++ b/src/main/java/org/joda/time/DateTimeZone.java
@@ -514,9 +514,10 @@ public abstract class DateTimeZone implements Serializable {
             Provider provider = new ZoneInfoProvider("org/joda/time/tz/data");
             return validateProvider(provider);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            // ignored
         }
         // approach 4
+        System.err.println("Couldn't obtain a ZoneInfoProvider so resorting to a UTCProvider");
         return new UTCProvider();
     }
 


### PR DESCRIPTION
Came across this when using joda-time-android and trying to write a unit test that runs outside of an Android machine. Because JodaTimeAndroid.init() is not called, no provider is available to JodaTime and therefore JodaTime resorts to a UTC provider. While this is perfectly acceptable for my unit test, the current way to silently handle this involves printing a dubiously useful stack trace. 

This change informs the user of what just happened and warns of what the silent fix is.