### PR TITLE
Basic support for quarters of a year

### DIFF
--- a/src/main/java/org/joda/time/Chronology.java
+++ b/src/main/java/org/joda/time/Chronology.java
@@ -433,6 +433,22 @@ public abstract class Chronology {
      */
     public abstract DateTimeField monthOfYear();
 
+    // Quarter
+    //-----------------------------------------------------------------------
+    /**
+     * Get the quarter duration field for this chronology.
+     *
+     * @return DurationField or UnsupportedDurationField if unsupported
+     */
+    public abstract DurationField quarters();
+
+    /**
+     * Get the quarter of year field for this chronology.
+     *
+     * @return DateTimeField or UnsupportedDateTimeField if unsupported
+     */
+    public abstract DateTimeField quarterOfYear();
+
     // Year
     //-----------------------------------------------------------------------
     /**

--- a/src/main/java/org/joda/time/DateTime.java
+++ b/src/main/java/org/joda/time/DateTime.java
@@ -81,7 +81,7 @@ public final class DateTime
     /**
      * Obtains a {@code DateTime} set to the current system millisecond time
      * using <code>ISOChronology</code> in the default time zone.
-     * 
+     *
      * @return the current date-time, not null
      * @since 2.0
      */
@@ -140,7 +140,7 @@ public final class DateTime
      * {@code new DateTime("2010-06-30T01:20+02:00"))} are NOT equal.
      * The object produced via this method has a zone of {@code DateTimeZone.forOffsetHours(2)}.
      * The object produced via the constructor has a zone of {@code DateTimeZone.getDefault()}.
-     * 
+     *
      * @param str  the string to parse, not null
      * @since 2.0
      */
@@ -151,7 +151,7 @@ public final class DateTime
 
     /**
      * Parses a {@code DateTime} from the specified string using a formatter.
-     * 
+     *
      * @param str  the string to parse, not null
      * @param formatter  the formatter to use, not null
      * @since 2.0
@@ -164,7 +164,7 @@ public final class DateTime
     /**
      * Constructs an instance set to the current system millisecond time
      * using <code>ISOChronology</code> in the default time zone.
-     * 
+     *
      * @see #now()
      */
     public DateTime() {
@@ -536,7 +536,7 @@ public final class DateTime
     //-----------------------------------------------------------------------
     /**
      * Get this object as a DateTime by returning <code>this</code>.
-     * 
+     *
      * @return <code>this</code>
      */
     public DateTime toDateTime() {
@@ -546,7 +546,7 @@ public final class DateTime
     /**
      * Get this object as a DateTime using ISOChronology in the default zone,
      * returning <code>this</code> if possible.
-     * 
+     *
      * @return a DateTime using the same millis
      */
     public DateTime toDateTimeISO() {
@@ -558,7 +558,7 @@ public final class DateTime
 
     /**
      * Get this object as a DateTime, returning <code>this</code> if possible.
-     * 
+     *
      * @param zone time zone to apply, or default if null
      * @return a DateTime using the same millis
      */
@@ -572,7 +572,7 @@ public final class DateTime
 
     /**
      * Get this object as a DateTime, returning <code>this</code> if possible.
-     * 
+     *
      * @param chronology chronology to apply, or ISOChronology if null
      * @return a DateTime using the same millis
      */
@@ -657,7 +657,7 @@ public final class DateTime
         if (newZone == originalZone) {
             return this;
         }
-        
+
         long millis = originalZone.getMillisKeepLocal(newZone, getMillis());
         return new DateTime(millis, getChronology().withZone(newZone));
     }
@@ -865,7 +865,7 @@ public final class DateTime
      * DateTime added = dt.plusYears(6);
      * DateTime added = dt.plus(Period.years(6));
      * </pre>
-     * 
+     *
      * @param fieldType  the field type to add to, not null
      * @param amount  the amount to add
      * @return a copy of this datetime with the field updated
@@ -888,7 +888,7 @@ public final class DateTime
      * Returns a copy of this datetime with the specified duration added.
      * <p>
      * If the addition is zero, then <code>this</code> is returned.
-     * 
+     *
      * @param durationToAdd  the duration to add to this one
      * @param scalar  the amount of times to add, such as -1 to subtract once
      * @return a copy of this datetime with the duration added
@@ -906,7 +906,7 @@ public final class DateTime
      * Returns a copy of this datetime with the specified duration added.
      * <p>
      * If the addition is zero, then <code>this</code> is returned.
-     * 
+     *
      * @param durationToAdd  the duration to add to this one, null means zero
      * @param scalar  the amount of times to add, such as -1 to subtract once
      * @return a copy of this datetime with the duration added
@@ -928,7 +928,7 @@ public final class DateTime
      * period instances. Adding one field is best achieved using methods
      * like {@link #withFieldAdded(DurationFieldType, int)}
      * or {@link #plusYears(int)}.
-     * 
+     *
      * @param period  the period to add to this one, null means zero
      * @param scalar  the amount of times to add, such as -1 to subtract once
      * @return a copy of this datetime with the period added
@@ -948,7 +948,7 @@ public final class DateTime
      * <p>
      * If the amount is zero or null, then <code>this</code> is returned.
      * This datetime instance is immutable and unaffected by this method call.
-     * 
+     *
      * @param duration  the duration, in millis, to add to this one
      * @return a copy of this datetime with the duration added
      * @throws ArithmeticException if the new datetime exceeds the capacity of a long
@@ -962,7 +962,7 @@ public final class DateTime
      * <p>
      * If the amount is zero or null, then <code>this</code> is returned.
      * This datetime instance is immutable and unaffected by this method call.
-     * 
+     *
      * @param duration  the duration to add to this one, null means zero
      * @return a copy of this datetime with the duration added
      * @throws ArithmeticException if the new datetime exceeds the capacity of a long
@@ -988,7 +988,7 @@ public final class DateTime
      * <p>
      * If the amount is zero or null, then <code>this</code> is returned.
      * This datetime instance is immutable and unaffected by this method call.
-     * 
+     *
      * @param period  the duration to add to this one, null means zero
      * @return a copy of this datetime with the period added
      * @throws ArithmeticException if the new datetime exceeds the capacity of a long
@@ -1236,7 +1236,7 @@ public final class DateTime
      * <p>
      * If the amount is zero or null, then <code>this</code> is returned.
      * This datetime instance is immutable and unaffected by this method call.
-     * 
+     *
      * @param duration  the duration, in millis, to reduce this instant by
      * @return a copy of this datetime with the duration taken away
      * @throws ArithmeticException if the new datetime exceeds the capacity of a long
@@ -1250,7 +1250,7 @@ public final class DateTime
      * <p>
      * If the amount is zero or null, then <code>this</code> is returned.
      * This datetime instance is immutable and unaffected by this method call.
-     * 
+     *
      * @param duration  the duration to reduce this instant by
      * @return a copy of this datetime with the duration taken away
      * @throws ArithmeticException if the new datetime exceeds the capacity of a long
@@ -1277,7 +1277,7 @@ public final class DateTime
      * <p>
      * If the amount is zero or null, then <code>this</code> is returned.
      * This datetime instance is immutable and unaffected by this method call.
-     * 
+     *
      * @param period  the period to reduce this instant by
      * @return a copy of this datetime with the period taken away
      * @throws ArithmeticException if the new datetime exceeds the capacity of a long
@@ -1544,7 +1544,7 @@ public final class DateTime
     /**
      * Converts this object to a <code>DateMidnight</code> using the
      * same millis and chronology.
-     * 
+     *
      * @return a DateMidnight using the same millis and chronology
      * @deprecated DateMidnight is deprecated
      */
@@ -1556,7 +1556,7 @@ public final class DateTime
     /**
      * Converts this object to a <code>YearMonthDay</code> using the
      * same millis and chronology.
-     * 
+     *
      * @return a YearMonthDay using the same millis and chronology
      * @deprecated Use LocalDate instead of YearMonthDay
      */
@@ -1568,7 +1568,7 @@ public final class DateTime
     /**
      * Converts this object to a <code>TimeOfDay</code> using the
      * same millis and chronology.
-     * 
+     *
      * @return a TimeOfDay using the same millis and chronology
      * @deprecated Use LocalTime instead of TimeOfDay
      */
@@ -1883,7 +1883,7 @@ public final class DateTime
     //-----------------------------------------------------------------------
     /**
      * Get the era property which provides access to advanced functionality.
-     * 
+     *
      * @return the era property
      */
     public Property era() {
@@ -1892,7 +1892,7 @@ public final class DateTime
 
     /**
      * Get the century of era property which provides access to advanced functionality.
-     * 
+     *
      * @return the year of era property
      */
     public Property centuryOfEra() {
@@ -1901,7 +1901,7 @@ public final class DateTime
 
     /**
      * Get the year of century property which provides access to advanced functionality.
-     * 
+     *
      * @return the year of era property
      */
     public Property yearOfCentury() {
@@ -1910,7 +1910,7 @@ public final class DateTime
 
     /**
      * Get the year of era property which provides access to advanced functionality.
-     * 
+     *
      * @return the year of era property
      */
     public Property yearOfEra() {
@@ -1919,7 +1919,7 @@ public final class DateTime
 
     /**
      * Get the year property which provides access to advanced functionality.
-     * 
+     *
      * @return the year property
      */
     public Property year() {
@@ -1928,7 +1928,7 @@ public final class DateTime
 
     /**
      * Get the year of a week based year property which provides access to advanced functionality.
-     * 
+     *
      * @return the year of a week based year property
      */
     public Property weekyear() {
@@ -1937,7 +1937,7 @@ public final class DateTime
 
     /**
      * Get the month of year property which provides access to advanced functionality.
-     * 
+     *
      * @return the month of year property
      */
     public Property monthOfYear() {
@@ -1945,8 +1945,16 @@ public final class DateTime
     }
 
     /**
+     * Get the quarter of year property which provides access to advanced functionality.
+     *
+     * @return the quarter of year property
+     */
+    public Property quarterOfYear() {
+        return new Property(this, getChronology().quarterOfYear());
+    }
+    /**
      * Get the week of a week based year property which provides access to advanced functionality.
-     * 
+     *
      * @return the week of a week based year property
      */
     public Property weekOfWeekyear() {
@@ -1955,7 +1963,7 @@ public final class DateTime
 
     /**
      * Get the day of year property which provides access to advanced functionality.
-     * 
+     *
      * @return the day of year property
      */
     public Property dayOfYear() {
@@ -1964,7 +1972,7 @@ public final class DateTime
 
     /**
      * Get the day of month property which provides access to advanced functionality.
-     * 
+     *
      * @return the day of month property
      */
     public Property dayOfMonth() {
@@ -1973,7 +1981,7 @@ public final class DateTime
 
     /**
      * Get the day of week property which provides access to advanced functionality.
-     * 
+     *
      * @return the day of week property
      */
     public Property dayOfWeek() {
@@ -1984,7 +1992,7 @@ public final class DateTime
     //-----------------------------------------------------------------------
     /**
      * Get the hour of day field property which provides access to advanced functionality.
-     * 
+     *
      * @return the hour of day property
      */
     public Property hourOfDay() {
@@ -1993,7 +2001,7 @@ public final class DateTime
 
     /**
      * Get the minute of day property which provides access to advanced functionality.
-     * 
+     *
      * @return the minute of day property
      */
     public Property minuteOfDay() {
@@ -2002,7 +2010,7 @@ public final class DateTime
 
     /**
      * Get the minute of hour field property which provides access to advanced functionality.
-     * 
+     *
      * @return the minute of hour property
      */
     public Property minuteOfHour() {
@@ -2011,7 +2019,7 @@ public final class DateTime
 
     /**
      * Get the second of day property which provides access to advanced functionality.
-     * 
+     *
      * @return the second of day property
      */
     public Property secondOfDay() {
@@ -2020,7 +2028,7 @@ public final class DateTime
 
     /**
      * Get the second of minute field property which provides access to advanced functionality.
-     * 
+     *
      * @return the second of minute property
      */
     public Property secondOfMinute() {
@@ -2029,7 +2037,7 @@ public final class DateTime
 
     /**
      * Get the millis of day property which provides access to advanced functionality.
-     * 
+     *
      * @return the millis of day property
      */
     public Property millisOfDay() {
@@ -2038,7 +2046,7 @@ public final class DateTime
 
     /**
      * Get the millis of second property which provides access to advanced functionality.
-     * 
+     *
      * @return the millis of second property
      */
     public Property millisOfSecond() {
@@ -2076,18 +2084,18 @@ public final class DateTime
      * @since 1.0
      */
     public static final class Property extends AbstractReadableInstantFieldProperty {
-        
+
         /** Serialization version */
         private static final long serialVersionUID = -6983323811635733510L;
-        
+
         /** The instant this property is working against */
         private DateTime iInstant;
         /** The field this property is working against */
         private DateTimeField iField;
-        
+
         /**
          * Constructor.
-         * 
+         *
          * @param instant  the instant to set
          * @param field  the field to use
          */
@@ -2096,7 +2104,7 @@ public final class DateTime
             iInstant = instant;
             iField = field;
         }
-        
+
         /**
          * Writes the property in a safe serialization format.
          */
@@ -2117,41 +2125,41 @@ public final class DateTime
         //-----------------------------------------------------------------------
         /**
          * Gets the field being used.
-         * 
+         *
          * @return the field
          */
         public DateTimeField getField() {
             return iField;
         }
-        
+
         /**
          * Gets the milliseconds of the datetime that this property is linked to.
-         * 
+         *
          * @return the milliseconds
          */
         protected long getMillis() {
             return iInstant.getMillis();
         }
-        
+
         /**
          * Gets the chronology of the datetime that this property is linked to.
-         * 
+         *
          * @return the chronology
          * @since 1.4
          */
         protected Chronology getChronology() {
             return iInstant.getChronology();
         }
-        
+
         /**
          * Gets the datetime being used.
-         * 
+         *
          * @return the datetime
          */
         public DateTime getDateTime() {
             return iInstant;
         }
-        
+
         //-----------------------------------------------------------------------
         /**
          * Adds to this field in a copy of this DateTime.
@@ -2160,7 +2168,7 @@ public final class DateTime
          * This operation is faster than converting a DateTime to a MutableDateTime
          * and back again when setting one field. When setting multiple fields,
          * it is generally quicker to make the conversion to MutableDateTime.
-         * 
+         *
          * @param value  the value to add to the field in the copy
          * @return a copy of the DateTime with the field value changed
          * @throws IllegalArgumentException if the value isn't valid
@@ -2168,7 +2176,7 @@ public final class DateTime
         public DateTime addToCopy(int value) {
             return iInstant.withMillis(iField.add(iInstant.getMillis(), value));
         }
-        
+
         /**
          * Adds to this field in a copy of this DateTime.
          * <p>
@@ -2176,7 +2184,7 @@ public final class DateTime
          * This operation is faster than converting a DateTime to a MutableDateTime
          * and back again when setting one field. When setting multiple fields,
          * it is generally quicker to make the conversion to MutableDateTime.
-         * 
+         *
          * @param value  the value to add to the field in the copy
          * @return a copy of the DateTime with the field value changed
          * @throws IllegalArgumentException if the value isn't valid
@@ -2184,7 +2192,7 @@ public final class DateTime
         public DateTime addToCopy(long value) {
             return iInstant.withMillis(iField.add(iInstant.getMillis(), value));
         }
-        
+
         /**
          * Adds to this field, possibly wrapped, in a copy of this DateTime.
          * A wrapped operation only changes this field.
@@ -2194,7 +2202,7 @@ public final class DateTime
          * This operation is faster than converting a DateTime to a MutableDateTime
          * and back again when setting one field. When setting multiple fields,
          * it is generally quicker to make the conversion to MutableDateTime.
-         * 
+         *
          * @param value  the value to add to the field in the copy
          * @return a copy of the DateTime with the field value changed
          * @throws IllegalArgumentException if the value isn't valid
@@ -2202,7 +2210,7 @@ public final class DateTime
         public DateTime addWrapFieldToCopy(int value) {
             return iInstant.withMillis(iField.addWrapField(iInstant.getMillis(), value));
         }
-        
+
         //-----------------------------------------------------------------------
         /**
          * Sets this field in a copy of the DateTime.
@@ -2211,7 +2219,7 @@ public final class DateTime
          * This operation is faster than converting a DateTime to a MutableDateTime
          * and back again when setting one field. When setting multiple fields,
          * it is generally quicker to make the conversion to MutableDateTime.
-         * 
+         *
          * @param value  the value to set the field in the copy to
          * @return a copy of the DateTime with the field value changed
          * @throws IllegalArgumentException if the value isn't valid
@@ -2219,7 +2227,7 @@ public final class DateTime
         public DateTime setCopy(int value) {
             return iInstant.withMillis(iField.set(iInstant.getMillis(), value));
         }
-        
+
         /**
          * Sets this field in a copy of the DateTime to a parsed text value.
          * <p>
@@ -2227,7 +2235,7 @@ public final class DateTime
          * This operation is faster than converting a DateTime to a MutableDateTime
          * and back again when setting one field. When setting multiple fields,
          * it is generally quicker to make the conversion to MutableDateTime.
-         * 
+         *
          * @param text  the text value to set
          * @param locale  optional locale to use for selecting a text symbol
          * @return a copy of the DateTime with the field value changed
@@ -2236,7 +2244,7 @@ public final class DateTime
         public DateTime setCopy(String text, Locale locale) {
             return iInstant.withMillis(iField.set(iInstant.getMillis(), text, locale));
         }
-        
+
         /**
          * Sets this field in a copy of the DateTime to a parsed text value.
          * <p>
@@ -2244,7 +2252,7 @@ public final class DateTime
          * This operation is faster than converting a DateTime to a MutableDateTime
          * and back again when setting one field. When setting multiple fields,
          * it is generally quicker to make the conversion to MutableDateTime.
-         * 
+         *
          * @param text  the text value to set
          * @return a copy of the DateTime with the field value changed
          * @throws IllegalArgumentException if the text value isn't valid
@@ -2252,7 +2260,7 @@ public final class DateTime
         public DateTime setCopy(String text) {
             return setCopy(text, null);
         }
-        
+
         //-----------------------------------------------------------------------
         /**
          * Returns a new DateTime with this field set to the maximum value
@@ -2288,7 +2296,7 @@ public final class DateTime
                 throw ex;
             }
         }
-        
+
         /**
          * Returns a new DateTime with this field set to the minimum value
          * for this field.
@@ -2317,7 +2325,7 @@ public final class DateTime
                 throw ex;
             }
         }
-        
+
         //-----------------------------------------------------------------------
         /**
          * Rounds to the lowest whole unit of this field on a copy of this DateTime.
@@ -2327,7 +2335,7 @@ public final class DateTime
         public DateTime roundFloorCopy() {
             return iInstant.withMillis(iField.roundFloor(iInstant.getMillis()));
         }
-        
+
         /**
          * Rounds to the highest whole unit of this field on a copy of this DateTime.
          *
@@ -2336,7 +2344,7 @@ public final class DateTime
         public DateTime roundCeilingCopy() {
             return iInstant.withMillis(iField.roundCeiling(iInstant.getMillis()));
         }
-        
+
         /**
          * Rounds to the nearest whole unit of this field on a copy of this DateTime,
          * favoring the floor if halfway.
@@ -2346,7 +2354,7 @@ public final class DateTime
         public DateTime roundHalfFloorCopy() {
             return iInstant.withMillis(iField.roundHalfFloor(iInstant.getMillis()));
         }
-        
+
         /**
          * Rounds to the nearest whole unit of this field on a copy of this DateTime,
          * favoring the ceiling if halfway.
@@ -2356,7 +2364,7 @@ public final class DateTime
         public DateTime roundHalfCeilingCopy() {
             return iInstant.withMillis(iField.roundHalfCeiling(iInstant.getMillis()));
         }
-        
+
         /**
          * Rounds to the nearest whole unit of this field on a copy of this
          * DateTime.  If halfway, the ceiling is favored over the floor only if

--- a/src/main/java/org/joda/time/DateTimeFieldType.java
+++ b/src/main/java/org/joda/time/DateTimeFieldType.java
@@ -507,6 +507,8 @@ public abstract class DateTimeFieldType implements Serializable {
                     return chronology.dayOfYear();
                 case MONTH_OF_YEAR:
                     return chronology.monthOfYear();
+                case QUARTER_OF_YEAR:
+                    return chronology.quarterOfYear();
                 case DAY_OF_MONTH:
                     return chronology.dayOfMonth();
                 case WEEKYEAR_OF_CENTURY:

--- a/src/main/java/org/joda/time/DateTimeFieldType.java
+++ b/src/main/java/org/joda/time/DateTimeFieldType.java
@@ -67,7 +67,8 @@ public abstract class DateTimeFieldType implements Serializable {
         SECOND_OF_DAY = 20,
         SECOND_OF_MINUTE = 21,
         MILLIS_OF_DAY = 22,
-        MILLIS_OF_SECOND = 23;
+        MILLIS_OF_SECOND = 23,
+        QUARTER_OF_YEAR = 24;
 
     /** The era field type. */
     private static final DateTimeFieldType ERA_TYPE = new StandardDateTimeFieldType(
@@ -139,6 +140,9 @@ public abstract class DateTimeFieldType implements Serializable {
     /** The millisOfSecond field type. */
     private static final DateTimeFieldType MILLIS_OF_SECOND_TYPE = new StandardDateTimeFieldType(
         "millisOfSecond", MILLIS_OF_SECOND, DurationFieldType.millis(), DurationFieldType.seconds());
+    /** The quarterOfYear field type. */
+    private static final DateTimeFieldType QUARTER_OF_YEAR_TYPE = new StandardDateTimeFieldType(
+        "quarterOfYear", QUARTER_OF_YEAR, DurationFieldType.quarters(), DurationFieldType.years());
 
     /** The name of the field. */
     private final String iName;
@@ -316,6 +320,15 @@ public abstract class DateTimeFieldType implements Serializable {
      */
     public static DateTimeFieldType monthOfYear() {
         return MONTH_OF_YEAR_TYPE;
+    }
+
+    /**
+     * Get the quarter of year field type.
+     *
+     * @return the DateTimeFieldType constant
+     */
+    public static DateTimeFieldType quarterOfYear() {
+        return QUARTER_OF_YEAR_TYPE;
     }
 
     /**
@@ -585,6 +598,8 @@ public abstract class DateTimeFieldType implements Serializable {
                     return MILLIS_OF_DAY_TYPE;
                 case MILLIS_OF_SECOND:
                     return MILLIS_OF_SECOND_TYPE;
+                case QUARTER_OF_YEAR:
+                    return QUARTER_OF_YEAR_TYPE;
                 default:
                     // Shouldn't happen.
                     return this;

--- a/src/main/java/org/joda/time/DurationFieldType.java
+++ b/src/main/java/org/joda/time/DurationFieldType.java
@@ -54,7 +54,8 @@ public abstract class DurationFieldType implements Serializable {
         HOURS = 9,
         MINUTES = 10,
         SECONDS = 11,
-        MILLIS = 12;
+        MILLIS = 12,
+        QUARTERS = 13;
 
     /** The eras field type. */
     static final DurationFieldType ERAS_TYPE = new StandardDurationFieldType("eras", ERAS);
@@ -80,6 +81,8 @@ public abstract class DurationFieldType implements Serializable {
     static final DurationFieldType SECONDS_TYPE = new StandardDurationFieldType("seconds", SECONDS);
     /** The millis field type. */
     static final DurationFieldType MILLIS_TYPE = new StandardDurationFieldType("millis", MILLIS);
+    /** The quarters field type. */
+    static final DurationFieldType QUARTERS_TYPE = new StandardDurationFieldType("quarters", QUARTERS);
 
     /** The name of the field type. */
     private final String iName;
@@ -205,6 +208,16 @@ public abstract class DurationFieldType implements Serializable {
         return ERAS_TYPE;
     }
 
+    /**
+     * Get the quarters field type.
+     *
+     * @return the DurationFieldType constant
+     */
+    public static DurationFieldType quarters() {
+        return QUARTERS_TYPE;
+    }
+
+
     //-----------------------------------------------------------------------
     /**
      * Get the name of the field.
@@ -306,6 +319,8 @@ public abstract class DurationFieldType implements Serializable {
                     return chronology.seconds();
                 case MILLIS:
                     return chronology.millis();
+                case QUARTERS:
+                    return chronology.quarters();
                 default:
                     // Shouldn't happen.
                     throw new InternalError();
@@ -343,6 +358,8 @@ public abstract class DurationFieldType implements Serializable {
                     return SECONDS_TYPE;
                 case MILLIS:
                     return MILLIS_TYPE;
+                case QUARTERS:
+                    return QUARTERS_TYPE;
                 default:
                     // Shouldn't happen.
                     return this;

--- a/src/main/java/org/joda/time/base/AbstractDateTime.java
+++ b/src/main/java/org/joda/time/base/AbstractDateTime.java
@@ -29,7 +29,7 @@ import org.joda.time.format.DateTimeFormat;
  * AbstractDateTime provides the common behaviour for datetime classes.
  * <p>
  * This class should generally not be used directly by API users.
- * The {@link ReadableDateTime} interface should be used when different 
+ * The {@link ReadableDateTime} interface should be used when different
  * kinds of date/time objects are to be referenced.
  * <p>
  * Whenever you want to implement <code>ReadableDateTime</code> you should
@@ -73,7 +73,7 @@ public abstract class AbstractDateTime
     //-----------------------------------------------------------------------
     /**
      * Get the era field value.
-     * 
+     *
      * @return the era
      */
     public int getEra() {
@@ -82,7 +82,7 @@ public abstract class AbstractDateTime
 
     /**
      * Get the year of era field value.
-     * 
+     *
      * @return the year of era
      */
     public int getCenturyOfEra() {
@@ -91,7 +91,7 @@ public abstract class AbstractDateTime
 
     /**
      * Get the year of era field value.
-     * 
+     *
      * @return the year of era
      */
     public int getYearOfEra() {
@@ -100,7 +100,7 @@ public abstract class AbstractDateTime
 
     /**
      * Get the year of century field value.
-     * 
+     *
      * @return the year of century
      */
     public int getYearOfCentury() {
@@ -109,7 +109,7 @@ public abstract class AbstractDateTime
 
     /**
      * Get the year field value.
-     * 
+     *
      * @return the year
      */
     public int getYear() {
@@ -124,7 +124,7 @@ public abstract class AbstractDateTime
      * is that in which at least 4 days are in the year. As a result of this
      * definition, day 1 of the first week may be in the previous year.
      * The weekyear allows you to query the effective year for that day.
-     * 
+     *
      * @return the year of a week based year
      */
     public int getWeekyear() {
@@ -133,11 +133,20 @@ public abstract class AbstractDateTime
 
     /**
      * Get the month of year field value.
-     * 
+     *
      * @return the month of year
      */
     public int getMonthOfYear() {
         return getChronology().monthOfYear().get(getMillis());
+    }
+
+    /**
+     * Get the month of year field value.
+     *
+     * @return the month of year
+     */
+    public int getQuarterOfYear() {
+        return getChronology().quarterOfYear().get(getMillis());
     }
 
     /**
@@ -147,7 +156,7 @@ public abstract class AbstractDateTime
      * In the standard ISO8601 week algorithm, the first week of the year
      * is that in which at least 4 days are in the year. As a result of this
      * definition, day 1 of the first week may be in the previous year.
-     * 
+     *
      * @return the week of a week based year
      */
     public int getWeekOfWeekyear() {
@@ -156,7 +165,7 @@ public abstract class AbstractDateTime
 
     /**
      * Get the day of year field value.
-     * 
+     *
      * @return the day of year
      */
     public int getDayOfYear() {
@@ -167,7 +176,7 @@ public abstract class AbstractDateTime
      * Get the day of month field value.
      * <p>
      * The values for the day of month are defined in {@link org.joda.time.DateTimeConstants}.
-     * 
+     *
      * @return the day of month
      */
     public int getDayOfMonth() {
@@ -178,7 +187,7 @@ public abstract class AbstractDateTime
      * Get the day of week field value.
      * <p>
      * The values for the day of week are defined in {@link org.joda.time.DateTimeConstants}.
-     * 
+     *
      * @return the day of week
      */
     public int getDayOfWeek() {
@@ -306,7 +315,7 @@ public abstract class AbstractDateTime
      * This can be confusing, as the equals and hashCode methods use both
      * chronology and time-zone. If two objects are not {@code equal} but have the
      * same {@code toString} then either the chronology or time-zone differs.
-     * 
+     *
      * @return ISO8601 time formatted string, not null
      */
     @ToString

--- a/src/main/java/org/joda/time/base/AbstractInstant.java
+++ b/src/main/java/org/joda/time/base/AbstractInstant.java
@@ -38,8 +38,8 @@ import org.joda.time.format.ISODateTimeFormat;
  * This class has no concept of a chronology, all methods work on the
  * millisecond instant.
  * <p>
- * This class should generally not be used directly by API users. The 
- * {@link ReadableInstant} interface should be used when different 
+ * This class should generally not be used directly by API users. The
+ * {@link ReadableInstant} interface should be used when different
  * kinds of date/time objects are to be referenced.
  * <p>
  * Whenever you want to implement <code>ReadableInstant</code> you should
@@ -64,7 +64,7 @@ public abstract class AbstractInstant implements ReadableInstant {
     //-----------------------------------------------------------------------
     /**
      * Gets the time zone of the instant from the chronology.
-     * 
+     *
      * @return the DateTimeZone that the instant is using, never null
      */
     public DateTimeZone getZone() {
@@ -115,7 +115,7 @@ public abstract class AbstractInstant implements ReadableInstant {
      * Instant dt = new Instant();
      * int gjYear = dt.get(Chronology.getCoptic().year());
      * </pre>
-     * 
+     *
      * @param field  the DateTimeField to use, not null
      * @return the value
      * @throws IllegalArgumentException if the field is null
@@ -130,7 +130,7 @@ public abstract class AbstractInstant implements ReadableInstant {
     //-----------------------------------------------------------------------
     /**
      * Get this object as an Instant.
-     * 
+     *
      * @return an Instant using the same millis
      */
     public Instant toInstant() {
@@ -157,7 +157,7 @@ public abstract class AbstractInstant implements ReadableInstant {
 
     /**
      * Get this object as a DateTime using the same chronology but a different zone.
-     * 
+     *
      * @param zone time zone to apply, or default if null
      * @return a DateTime using the same millis
      */
@@ -169,7 +169,7 @@ public abstract class AbstractInstant implements ReadableInstant {
 
     /**
      * Get this object as a DateTime using the given chronology and its zone.
-     * 
+     *
      * @param chronology chronology to apply, or ISOChronology if null
      * @return a DateTime using the same millis
      */
@@ -202,7 +202,7 @@ public abstract class AbstractInstant implements ReadableInstant {
 
     /**
      * Get this object as a MutableDateTime using the same chronology but a different zone.
-     * 
+     *
      * @param zone time zone to apply, or default if null
      * @return a MutableDateTime using the same millis
      */
@@ -214,7 +214,7 @@ public abstract class AbstractInstant implements ReadableInstant {
 
     /**
      * Get this object as a MutableDateTime using the given chronology and its zone.
-     * 
+     *
      * @param chronology chronology to apply, or ISOChronology if null
      * @return a MutableDateTime using the same millis
      */
@@ -296,10 +296,10 @@ public abstract class AbstractInstant implements ReadableInstant {
         if (this == other) {
             return 0;
         }
-        
+
         long otherMillis = other.getMillis();
         long thisMillis = getMillis();
-        
+
         // cannot do (thisMillis - otherMillis) as can overflow
         if (thisMillis == otherMillis) {
             return 0;
@@ -326,7 +326,7 @@ public abstract class AbstractInstant implements ReadableInstant {
     /**
      * Is this instant after the current instant
      * comparing solely by millisecond.
-     * 
+     *
      * @return true if this instant is after the current instant
      */
     public boolean isAfterNow() {
@@ -360,7 +360,7 @@ public abstract class AbstractInstant implements ReadableInstant {
     /**
      * Is this instant before the current instant
      * comparing solely by millisecond.
-     * 
+     *
      * @return true if this instant is before the current instant
      */
     public boolean isBeforeNow() {
@@ -394,7 +394,7 @@ public abstract class AbstractInstant implements ReadableInstant {
     /**
      * Is this instant equal to the current instant
      * comparing solely by millisecond.
-     * 
+     *
      * @return true if this instant is equal to the current instant
      */
     public boolean isEqualNow() {
@@ -416,7 +416,7 @@ public abstract class AbstractInstant implements ReadableInstant {
     //-----------------------------------------------------------------------
     /**
      * Output the date time in ISO8601 format (yyyy-MM-ddTHH:mm:ss.SSSZZ).
-     * 
+     *
      * @return ISO8601 time formatted string, not null
      */
     @ToString

--- a/src/main/java/org/joda/time/base/AbstractPartial.java
+++ b/src/main/java/org/joda/time/base/AbstractPartial.java
@@ -59,7 +59,7 @@ public abstract class AbstractPartial
      * Gets the field for a specific index in the chronology specified.
      * <p>
      * This method must not use any instance variables.
-     * 
+     *
      * @param index  the index to retrieve
      * @param chrono  the chronology to use
      * @return the field
@@ -70,7 +70,7 @@ public abstract class AbstractPartial
     //-----------------------------------------------------------------------
     /**
      * Gets the field type at the specifed index.
-     * 
+     *
      * @param index  the index
      * @return the field type
      * @throws IndexOutOfBoundsException if the index is invalid
@@ -96,7 +96,7 @@ public abstract class AbstractPartial
 
     /**
      * Gets the field at the specifed index.
-     * 
+     *
      * @param index  the index
      * @return the field
      * @throws IndexOutOfBoundsException if the index is invalid
@@ -271,7 +271,7 @@ public abstract class AbstractPartial
     }
 
     /**
-     * Gets a hash code for the ReadablePartial that is compatible with the 
+     * Gets a hash code for the ReadablePartial that is compatible with the
      * equals method.
      *
      * @return a suitable hash code

--- a/src/main/java/org/joda/time/chrono/AssembledChronology.java
+++ b/src/main/java/org/joda/time/chrono/AssembledChronology.java
@@ -72,6 +72,7 @@ public abstract class AssembledChronology extends BaseChronology {
     private transient DateTimeField iWeekyear;
     private transient DateTimeField iWeekyearOfCentury;
     private transient DateTimeField iMonthOfYear;
+    private transient DateTimeField iQuarterOfYear;
     private transient DateTimeField iYear;
     private transient DateTimeField iYearOfEra;
     private transient DateTimeField iYearOfCentury;
@@ -260,6 +261,10 @@ public abstract class AssembledChronology extends BaseChronology {
         return iMonthOfYear;
     }
 
+    public final DateTimeField quarterOfYear() {
+        return iQuarterOfYear;
+    }
+
     public final DurationField years() {
         return iYears;
     }
@@ -358,6 +363,7 @@ public abstract class AssembledChronology extends BaseChronology {
             iWeekyear           = (f = fields.weekyear)           != null ? f : super.weekyear();
             iWeekyearOfCentury  = (f = fields.weekyearOfCentury)  != null ? f : super.weekyearOfCentury();
             iMonthOfYear        = (f = fields.monthOfYear)        != null ? f : super.monthOfYear();
+            iQuarterOfYear      = (f = fields.quarterOfYear)      != null ? f : super.quarterOfYear();
             iYear               = (f = fields.year)               != null ? f : super.year();
             iYearOfEra          = (f = fields.yearOfEra)          != null ? f : super.yearOfEra();
             iYearOfCentury      = (f = fields.yearOfCentury)      != null ? f : super.yearOfCentury();
@@ -369,7 +375,7 @@ public abstract class AssembledChronology extends BaseChronology {
         if (iBase == null) {
             flags = 0;
         } else {
-            flags = 
+            flags =
                 ((iHourOfDay      == iBase.hourOfDay()      &&
                   iMinuteOfHour   == iBase.minuteOfHour()   &&
                   iSecondOfMinute == iBase.secondOfMinute() &&
@@ -399,7 +405,7 @@ public abstract class AssembledChronology extends BaseChronology {
         public DurationField minutes;
         public DurationField hours;
         public DurationField halfdays;
-    
+
         public DurationField days;
         public DurationField weeks;
         public DurationField weekyears;
@@ -407,7 +413,7 @@ public abstract class AssembledChronology extends BaseChronology {
         public DurationField years;
         public DurationField centuries;
         public DurationField eras;
-    
+
         public DateTimeField millisOfSecond;
         public DateTimeField millisOfDay;
         public DateTimeField secondOfMinute;
@@ -419,7 +425,7 @@ public abstract class AssembledChronology extends BaseChronology {
         public DateTimeField hourOfHalfday;
         public DateTimeField clockhourOfHalfday;
         public DateTimeField halfdayOfDay;
-    
+
         public DateTimeField dayOfWeek;
         public DateTimeField dayOfMonth;
         public DateTimeField dayOfYear;
@@ -427,6 +433,7 @@ public abstract class AssembledChronology extends BaseChronology {
         public DateTimeField weekyear;
         public DateTimeField weekyearOfCentury;
         public DateTimeField monthOfYear;
+        public DateTimeField quarterOfYear;
         public DateTimeField year;
         public DateTimeField yearOfEra;
         public DateTimeField yearOfCentury;
@@ -535,6 +542,9 @@ public abstract class AssembledChronology extends BaseChronology {
                 }
                 if (isSupported(f = chrono.monthOfYear())) {
                     monthOfYear = f;
+                }
+                if (isSupported(f = chrono.quarterOfYear())) {
+                    quarterOfYear = f;
                 }
                 if (isSupported(f = chrono.year())) {
                     year = f;

--- a/src/main/java/org/joda/time/chrono/BaseChronology.java
+++ b/src/main/java/org/joda/time/chrono/BaseChronology.java
@@ -593,6 +593,14 @@ public abstract class BaseChronology
         return UnsupportedDateTimeField.getInstance(DateTimeFieldType.monthOfYear(), months());
     }
 
+    public DurationField quarters() {
+        return UnsupportedDurationField.getInstance(DurationFieldType.quarters());
+    }
+
+    public DateTimeField quarterOfYear() {
+        return UnsupportedDateTimeField.getInstance(DateTimeFieldType.quarterOfYear(), quarters());
+    }
+
     // Year
     //-----------------------------------------------------------------------
     /**

--- a/src/main/java/org/joda/time/chrono/BasicChronology.java
+++ b/src/main/java/org/joda/time/chrono/BasicChronology.java
@@ -92,7 +92,7 @@ abstract class BasicChronology extends AssembledChronology {
 
         cMillisOfDayField = new PreciseDateTimeField
             (DateTimeFieldType.millisOfDay(), cMillisField, cDaysField);
-             
+
         cSecondOfMinuteField = new PreciseDateTimeField
             (DateTimeFieldType.secondOfMinute(), cSecondsField, cMinutesField);
 
@@ -207,7 +207,7 @@ abstract class BasicChronology extends AssembledChronology {
     //-----------------------------------------------------------------------
     /**
      * Checks if this chronology instance equals another.
-     * 
+     *
      * @param obj  the object to compare to
      * @return true if equal
      * @since 1.6
@@ -226,7 +226,7 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * A suitable hash code for the chronology.
-     * 
+     *
      * @return the hash code
      * @since 1.6
      */
@@ -238,7 +238,7 @@ abstract class BasicChronology extends AssembledChronology {
     //-----------------------------------------------------------------------
     /**
      * Gets a debugging toString.
-     * 
+     *
      * @return a debugging string
      */
     public String toString() {
@@ -298,7 +298,7 @@ abstract class BasicChronology extends AssembledChronology {
         fields.centuryOfEra = new DividedDateTimeField(
             field, DateTimeFieldType.centuryOfEra(), 100);
         fields.centuries = fields.centuryOfEra.getDurationField();
-        
+
         field = new RemainderDateTimeField(
             (DividedDateTimeField) fields.centuryOfEra);
         fields.yearOfCentury = new OffsetDateTimeField(
@@ -309,14 +309,15 @@ abstract class BasicChronology extends AssembledChronology {
         fields.dayOfMonth = new BasicDayOfMonthDateTimeField(this, fields.days);
         fields.dayOfYear = new BasicDayOfYearDateTimeField(this, fields.days);
         fields.monthOfYear = new GJMonthOfYearDateTimeField(this);
+        fields.quarterOfYear = new BasicQuarterOfYearDateTimeField(this, 2);
         fields.weekyear = new BasicWeekyearDateTimeField(this);
         fields.weekOfWeekyear = new BasicWeekOfWeekyearDateTimeField(this, fields.weeks);
-        
+
         field = new RemainderDateTimeField(
             fields.weekyear, fields.centuries, DateTimeFieldType.weekyearOfCentury(), 100);
         fields.weekyearOfCentury = new OffsetDateTimeField(
             field, DateTimeFieldType.weekyearOfCentury(), 1);
-        
+
         // The remaining (imprecise) durations are available from the newly
         // created datetime fields.
         fields.years = fields.year.getDurationField();
@@ -365,7 +366,7 @@ abstract class BasicChronology extends AssembledChronology {
     long getFirstWeekOfYearMillis(int year) {
         long jan1millis = getYearMillis(year);
         int jan1dayOfWeek = getDayOfWeek(jan1millis);
-        
+
         if (jan1dayOfWeek > (8 - iMinDaysInFirstWeek)) {
             // First week is end of previous year because it doesn't have enough days.
             return jan1millis + (8 - jan1dayOfWeek)
@@ -413,7 +414,7 @@ abstract class BasicChronology extends AssembledChronology {
         millis += getTotalMillisByYearMonth(year, month);
         return millis + (dayOfMonth - 1) * (long)DateTimeConstants.MILLIS_PER_DAY;
     }
-    
+
     /**
      * @param instant millis from 1970-01-01T00:00:00Z
      */
@@ -460,6 +461,10 @@ abstract class BasicChronology extends AssembledChronology {
      */
     int getMonthOfYear(long millis) {
         return getMonthOfYear(millis, getYear(millis));
+    }
+
+    int getQuarterOfYear(long millis) {
+        return (getMonthOfYear(millis) - 1) / 3 + 1;
     }
 
     /**
@@ -585,7 +590,7 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Gets the maximum number of days in any month.
-     * 
+     *
      * @return 31
      */
     int getDaysInMonthMax() {
@@ -594,7 +599,7 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Gets the maximum number of days in the month specified by the instant.
-     * 
+     *
      * @param instant  millis from 1970-01-01T00:00:00Z
      * @return the maximum number of days in the month
      */
@@ -608,7 +613,7 @@ abstract class BasicChronology extends AssembledChronology {
      * Gets the maximum number of days in the month specified by the instant.
      * The value represents what the user is trying to set, and can be
      * used to optimise this method.
-     * 
+     *
      * @param instant  millis from 1970-01-01T00:00:00Z
      * @param value  the value being set
      * @return the maximum number of days in the month
@@ -620,7 +625,7 @@ abstract class BasicChronology extends AssembledChronology {
     //-----------------------------------------------------------------------
     /**
      * Gets the milliseconds for a date at midnight.
-     * 
+     *
      * @param year  the year
      * @param monthOfYear  the month
      * @param dayOfMonth  the day
@@ -642,7 +647,7 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Gets the difference between the two instants in years.
-     * 
+     *
      * @param minuendInstant  the first instant
      * @param subtrahendInstant  the second instant
      * @return the difference
@@ -651,7 +656,7 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Is the specified year a leap year?
-     * 
+     *
      * @param year  the year to test
      * @return true if leap
      */
@@ -659,7 +664,7 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Is the specified instant a leap day?
-     * 
+     *
      * @param instant  the instant to test
      * @return true if leap, default is false
      */
@@ -669,7 +674,7 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Gets the number of days in the specified month and year.
-     * 
+     *
      * @param year  the year
      * @param month  the month
      * @return the number of days
@@ -678,7 +683,7 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Gets the maximum days in the specified month.
-     * 
+     *
      * @param month  the month
      * @return the max days
      */
@@ -687,7 +692,7 @@ abstract class BasicChronology extends AssembledChronology {
     /**
      * Gets the total number of millis elapsed in this year at the start
      * of the specified month, such as zero for month 1.
-     * 
+     *
      * @param year  the year
      * @param month  the month
      * @return the elapsed millis at the start of the month
@@ -696,21 +701,21 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Gets the millisecond value of the first day of the year.
-     * 
+     *
      * @return the milliseconds for the first of the year
      */
     abstract long calculateFirstDayOfYearMillis(int year);
 
     /**
      * Gets the minimum supported year.
-     * 
+     *
      * @return the year
      */
     abstract int getMinYear();
 
     /**
      * Gets the maximum supported year.
-     * 
+     *
      * @return the year
      */
     abstract int getMaxYear();
@@ -718,7 +723,7 @@ abstract class BasicChronology extends AssembledChronology {
     /**
      * Gets the maximum month for the specified year.
      * This implementation calls getMaxMonth().
-     * 
+     *
      * @param year  the year
      * @return the maximum month value
      */
@@ -728,7 +733,7 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Gets the maximum number of months.
-     * 
+     *
      * @return 12
      */
     int getMaxMonth() {
@@ -737,21 +742,21 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Gets an average value for the milliseconds per year.
-     * 
+     *
      * @return the millis per year
      */
     abstract long getAverageMillisPerYear();
 
     /**
      * Gets an average value for the milliseconds per year, divided by two.
-     * 
+     *
      * @return the millis per year divided by two
      */
     abstract long getAverageMillisPerYearDividedByTwo();
 
     /**
      * Gets an average value for the milliseconds per month.
-     * 
+     *
      * @return the millis per month
      */
     abstract long getAverageMillisPerMonth();
@@ -769,7 +774,7 @@ abstract class BasicChronology extends AssembledChronology {
 
     /**
      * Sets the year from an instant and year.
-     * 
+     *
      * @param instant  millis from 1970-01-01T00:00:00Z
      * @param year  the year to set
      * @return the updated millis

--- a/src/main/java/org/joda/time/chrono/BasicQuarterOfYearDateTimeField.java
+++ b/src/main/java/org/joda/time/chrono/BasicQuarterOfYearDateTimeField.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2001-2013 Stephen Colebourne
+ *  Copyright 2001-2013 Andy Georges
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,12 +24,9 @@ import org.joda.time.field.FieldUtils;
 import org.joda.time.field.ImpreciseDateTimeField;
 
 /**
- * Provides time calculations for the month of the year component of time.
+ * Provides time calculations for the quarter of the year component of time.
  *
- * @author Guy Allard
- * @author Stephen Colebourne
- * @author Brian S O'Neill
- * @since 1.2, refactored from GJMonthOfYearDateTimeField
+ * @author Andy Georges
  */
 class BasicQuarterOfYearDateTimeField extends BasicMonthOfYearDateTimeField {
 

--- a/src/main/java/org/joda/time/chrono/BasicQuarterOfYearDateTimeField.java
+++ b/src/main/java/org/joda/time/chrono/BasicQuarterOfYearDateTimeField.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright 2001-2013 Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.time.chrono;
+
+import org.joda.time.DateTimeConstants;
+import org.joda.time.DateTimeFieldType;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DurationField;
+import org.joda.time.ReadablePartial;
+import org.joda.time.field.FieldUtils;
+import org.joda.time.field.ImpreciseDateTimeField;
+
+/**
+ * Provides time calculations for the month of the year component of time.
+ *
+ * @author Guy Allard
+ * @author Stephen Colebourne
+ * @author Brian S O'Neill
+ * @since 1.2, refactored from GJMonthOfYearDateTimeField
+ */
+class BasicQuarterOfYearDateTimeField extends BasicMonthOfYearDateTimeField {
+
+    private static final int MIN = 1;
+
+    /**
+     * Restricted constructor.
+     *
+     * @param leapMonth the month of year that leaps
+     */
+    BasicQuarterOfYearDateTimeField(BasicChronology chronology, int leapMonth) {
+        super(chronology, leapMonth);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Get the Quarter component of the specified time instant.
+     *
+     * @see org.joda.time.DateTimeField#get(long)
+     * @see org.joda.time.ReadableDateTime#getMonthOfYear()
+     * @param instant  the time instant in millis to query.
+     * @return the quarter extracted from the input.
+     */
+    public int get(long instant) {
+        return super.get(instant) % 4 + 1;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Add the specified month to the specified time instant.
+     * The amount added may be negative.<p>
+     * If the new month has less total days than the specified
+     * day of the month, this value is coerced to the nearest
+     * sane value. e.g.<p>
+     * 07-31 - (1 month) = 06-30<p>
+     * 03-31 - (1 month) = 02-28 or 02-29 depending<p>
+     *
+     * @see org.joda.time.DateTimeField#add
+     * @see org.joda.time.ReadWritableDateTime#addMonths(int)
+     * @param instant  the time instant in millis to update.
+     * @param months  the months to add (can be negative).
+     * @return the updated time instant.
+     */
+    public long add(long instant, int quarters) {
+        return super.add(instant, quarters * 3);
+    }
+
+    //-----------------------------------------------------------------------
+    public long add(long instant, long quarters) {
+        return super.add(instant, quarters * 3);
+    }
+
+    //-----------------------------------------------------------------------
+    public int[] add(ReadablePartial partial, int fieldIndex, int[] values, int valueToAdd) {
+        if (valueToAdd == 0) {
+            return values;
+        }
+        if (partial.size() > 0 && partial.getFieldType(0).equals(DateTimeFieldType.quarterOfYear()) && fieldIndex == 2) {
+            return super.add(partial, fieldIndex, values, valueToAdd * 3);
+        }
+        return super.add(partial, fieldIndex, values, valueToAdd);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Add to the Month component of the specified time instant
+     * wrapping around within that component if necessary.
+     *
+     * @see org.joda.time.DateTimeField#addWrapF125ggield
+     * @param instant  the time instant in millis to update.
+     * @param months  the months to add (can be negative).
+     * @return the updated time instant.
+     */
+    public long addWrapField(long instant, int quarters) {
+        return super.addWrapField(instant, quarters * 3);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Set the month component of the specified time instant.<p>
+     * If the new month has less total days than the specified
+     * day of the month, this value is coerced to the nearest
+     * sane value. e.g.<p>
+     * 07-31 to month 6 = 06-30<p>
+     * 03-31 to month 2 = 02-28 or 02-29 depending<p>
+     *
+     * @param instant  the time instant in millis to update.
+     * @param month  the month (1,12) to update the time to.
+     * @return the updated time instant.
+     * @throws IllegalArgumentException  if month is invalid
+     */
+    public long set(long instant, int quarter) {
+        return super.set(instant, quarter * 3);
+    }
+
+    //-----------------------------------------------------------------------
+    public int getMinimumValue() {
+        return 1;
+    }
+
+    //-----------------------------------------------------------------------
+    public int getMaximumValue() {
+        return 4;
+    }
+}

--- a/src/main/java/org/joda/time/chrono/BasicQuarterOfYearDateTimeField.java
+++ b/src/main/java/org/joda/time/chrono/BasicQuarterOfYearDateTimeField.java
@@ -54,7 +54,7 @@ class BasicQuarterOfYearDateTimeField extends BasicMonthOfYearDateTimeField {
      * @return the quarter extracted from the input.
      */
     public int get(long instant) {
-        return super.get(instant) % 4 + 1;
+        return (super.get(instant) - 1) / 3 + 1;
     }
 
     //-----------------------------------------------------------------------

--- a/src/main/java/org/joda/time/format/DateTimeFormat.java
+++ b/src/main/java/org/joda/time/format/DateTimeFormat.java
@@ -564,6 +564,7 @@ public class DateTimeFormat {
                 break;
             case 'Q': // quarter
                 builder.appendQuarterOfYear(tokenLen);
+                break;
             default:
                 throw new IllegalArgumentException
                     ("Illegal pattern component: " + token);

--- a/src/main/java/org/joda/time/format/DateTimeFormat.java
+++ b/src/main/java/org/joda/time/format/DateTimeFormat.java
@@ -562,6 +562,8 @@ public class DateTimeFormat {
                     builder.appendLiteral(new String(sub));
                 }
                 break;
+            case 'Q': // quarter
+                builder.appendQuarterOfYear(tokenLen);
             default:
                 throw new IllegalArgumentException
                     ("Illegal pattern component: " + token);

--- a/src/main/java/org/joda/time/format/DateTimeFormatterBuilder.java
+++ b/src/main/java/org/joda/time/format/DateTimeFormatterBuilder.java
@@ -818,6 +818,16 @@ public class DateTimeFormatterBuilder {
     }
 
     /**
+     * Instructs the printer to emit a numeric quarterOfYear field.
+     *
+     * @param minDigits  minimum number of digits to print
+     * @return this DateTimeFormatterBuilder, for chaining
+     */
+    public DateTimeFormatterBuilder appendQuarterOfYear(int minDigits) {
+        return appendDecimal(DateTimeFieldType.quarterOfYear(), minDigits, 1);
+    }
+
+    /**
      * Instructs the printer to emit a numeric year field.
      *
      * @param minDigits  minimum number of digits to <i>print</i>
@@ -983,7 +993,7 @@ public class DateTimeFormatterBuilder {
      *
      * @return this DateTimeFormatterBuilder, for chaining
      */
-    public DateTimeFormatterBuilder appendMonthOfYearText() { 
+    public DateTimeFormatterBuilder appendMonthOfYearText() {
         return appendText(DateTimeFieldType.monthOfYear());
     }
 
@@ -1313,7 +1323,7 @@ public class DateTimeFormatterBuilder {
                     positive = c == '+';
 
                     // Next character must be a digit.
-                    if (length + 1 >= limit || 
+                    if (length + 1 >= limit ||
                         (c = text.charAt(position + length + 1)) < '0' || c > '9') {
                         break;
                     }

--- a/src/test/java/org/joda/time/TestAbstractPartial.java
+++ b/src/test/java/org/joda/time/TestAbstractPartial.java
@@ -31,20 +31,20 @@ import org.joda.time.field.AbstractPartialFieldProperty;
 public class TestAbstractPartial extends TestCase {
 
     private static final DateTimeZone PARIS = DateTimeZone.forID("Europe/Paris");
-    
+
     private long TEST_TIME_NOW =
             (31L + 28L + 31L + 30L + 31L + 9L -1L) * DateTimeConstants.MILLIS_PER_DAY;
-            
+
     private long TEST_TIME1 =
         (31L + 28L + 31L + 6L -1L) * DateTimeConstants.MILLIS_PER_DAY
         + 12L * DateTimeConstants.MILLIS_PER_HOUR
         + 24L * DateTimeConstants.MILLIS_PER_MINUTE;
-        
+
     private long TEST_TIME2 =
         (365L + 31L + 28L + 31L + 30L + 7L -1L) * DateTimeConstants.MILLIS_PER_DAY
         + 14L * DateTimeConstants.MILLIS_PER_HOUR
         + 28L * DateTimeConstants.MILLIS_PER_MINUTE;
-        
+
     private DateTimeZone zone = null;
 
     public static void main(String[] args) {
@@ -76,7 +76,7 @@ public class TestAbstractPartial extends TestCase {
         MockPartial mock = new MockPartial();
         assertEquals(1970, mock.getValue(0));
         assertEquals(1, mock.getValue(1));
-        
+
         try {
             mock.getValue(-1);
             fail();
@@ -99,7 +99,7 @@ public class TestAbstractPartial extends TestCase {
         MockPartial mock = new MockPartial();
         assertEquals(BuddhistChronology.getInstanceUTC().year(), mock.getField(0));
         assertEquals(BuddhistChronology.getInstanceUTC().monthOfYear(), mock.getField(1));
-        
+
         try {
             mock.getField(-1);
             fail();
@@ -114,7 +114,8 @@ public class TestAbstractPartial extends TestCase {
         MockPartial mock = new MockPartial();
         assertEquals(DateTimeFieldType.year(), mock.getFieldType(0));
         assertEquals(DateTimeFieldType.monthOfYear(), mock.getFieldType(1));
-        
+        //assertEquals(DateTimeFieldType.quarterOfYear(), mock.getFieldType(2));
+
         try {
             mock.getFieldType(-1);
             fail();
@@ -147,9 +148,9 @@ public class TestAbstractPartial extends TestCase {
 
     //-----------------------------------------------------------------------
     static class MockPartial extends AbstractPartial {
-        
+
         int[] val = new int[] {1970, 1};
-        
+
         MockPartial() {
             super();
         }
@@ -168,7 +169,7 @@ public class TestAbstractPartial extends TestCase {
         public int size() {
             return 2;
         }
-        
+
         public int getValue(int index) {
             return val[index];
         }
@@ -181,7 +182,7 @@ public class TestAbstractPartial extends TestCase {
             return BuddhistChronology.getInstanceUTC();
         }
     }
-    
+
     static class MockProperty0 extends AbstractPartialFieldProperty {
         MockPartial partial = new MockPartial();
         public DateTimeField getField() {

--- a/src/test/java/org/joda/time/TestDateTime_Basics.java
+++ b/src/test/java/org/joda/time/TestDateTime_Basics.java
@@ -64,32 +64,32 @@ public class TestDateTime_Basics extends TestCase {
     private static final BuddhistChronology BUDDHIST_UTC = BuddhistChronology.getInstanceUTC();
     private static final BuddhistChronology BUDDHIST_DEFAULT = BuddhistChronology.getInstance(LONDON);
     private static final CopticChronology COPTIC_DEFAULT = CopticChronology.getInstance(LONDON);
-    
-    long y2002days = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 
-                     366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 
+
+    long y2002days = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
+                     366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 +
                      365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
                      366 + 365;
-    long y2003days = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 
-                     366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 
+    long y2003days = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
+                     366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 +
                      365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
                      366 + 365 + 365;
-    
+
     // 2002-06-09
     private long TEST_TIME_NOW =
             (y2002days + 31L + 28L + 31L + 30L + 31L + 9L -1L) * DateTimeConstants.MILLIS_PER_DAY;
-            
+
     // 2002-04-05
     private long TEST_TIME1 =
             (y2002days + 31L + 28L + 31L + 5L -1L) * DateTimeConstants.MILLIS_PER_DAY
             + 12L * DateTimeConstants.MILLIS_PER_HOUR
             + 24L * DateTimeConstants.MILLIS_PER_MINUTE;
-        
+
     // 2003-05-06
     private long TEST_TIME2 =
             (y2003days + 31L + 28L + 31L + 30L + 6L -1L) * DateTimeConstants.MILLIS_PER_DAY
             + 14L * DateTimeConstants.MILLIS_PER_HOUR
             + 28L * DateTimeConstants.MILLIS_PER_MINUTE;
-    
+
     private DateTimeZone originalDateTimeZone = null;
     private TimeZone originalTimeZone = null;
     private Locale originalLocale = null;
@@ -142,6 +142,7 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(2002, test.get(ISO_DEFAULT.yearOfEra()));
         assertEquals(2002, test.get(ISO_DEFAULT.year()));
         assertEquals(6, test.get(ISO_DEFAULT.monthOfYear()));
+        assertEquals(2, test.get(ISO_DEFAULT.quarterOfYear()));
         assertEquals(9, test.get(ISO_DEFAULT.dayOfMonth()));
         assertEquals(2002, test.get(ISO_DEFAULT.weekyear()));
         assertEquals(23, test.get(ISO_DEFAULT.weekOfWeekyear()));
@@ -172,6 +173,7 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(2002, test.get(DateTimeFieldType.yearOfEra()));
         assertEquals(2002, test.get(DateTimeFieldType.year()));
         assertEquals(6, test.get(DateTimeFieldType.monthOfYear()));
+        assertEquals(2, test.get(DateTimeFieldType.quarterOfYear()));
         assertEquals(9, test.get(DateTimeFieldType.dayOfMonth()));
         assertEquals(2002, test.get(DateTimeFieldType.weekyear()));
         assertEquals(23, test.get(DateTimeFieldType.weekOfWeekyear()));
@@ -202,6 +204,7 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(true, test.isSupported(DateTimeFieldType.yearOfEra()));
         assertEquals(true, test.isSupported(DateTimeFieldType.year()));
         assertEquals(true, test.isSupported(DateTimeFieldType.monthOfYear()));
+        assertEquals(true, test.isSupported(DateTimeFieldType.quarterOfYear()));
         assertEquals(true, test.isSupported(DateTimeFieldType.dayOfMonth()));
         assertEquals(true, test.isSupported(DateTimeFieldType.weekyear()));
         assertEquals(true, test.isSupported(DateTimeFieldType.weekOfWeekyear()));
@@ -224,17 +227,18 @@ public class TestDateTime_Basics extends TestCase {
     //-----------------------------------------------------------------------
     public void testGetters() {
         DateTime test = new DateTime();
-        
+
         assertEquals(ISO_DEFAULT, test.getChronology());
         assertEquals(LONDON, test.getZone());
         assertEquals(TEST_TIME_NOW, test.getMillis());
-        
+
         assertEquals(1, test.getEra());
         assertEquals(20, test.getCenturyOfEra());
         assertEquals(2, test.getYearOfCentury());
         assertEquals(2002, test.getYearOfEra());
         assertEquals(2002, test.getYear());
         assertEquals(6, test.getMonthOfYear());
+        assertEquals(2, test.getQuarterOfYear());
         assertEquals(9, test.getDayOfMonth());
         assertEquals(2002, test.getWeekyear());
         assertEquals(23, test.getWeekOfWeekyear());
@@ -267,7 +271,7 @@ public class TestDateTime_Basics extends TestCase {
         check(test.withSecondOfMinute(6), 1970, 6, 9, 10, 20, 6, 40);
         check(test.withMillisOfSecond(6), 1970, 6, 9, 10, 20, 30, 6);
         check(test.withMillisOfDay(61234), 1970, 6, 9, 0, 1, 1, 234);
-        
+
         try {
             test.withMonthOfYear(0);
             fail();
@@ -289,7 +293,7 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(true, test1.hashCode() == test2.hashCode());
         assertEquals(true, test1.hashCode() == test1.hashCode());
         assertEquals(true, test2.hashCode() == test2.hashCode());
-        
+
         DateTime test3 = new DateTime(TEST_TIME2);
         assertEquals(false, test1.equals(test3));
         assertEquals(false, test2.equals(test3));
@@ -297,14 +301,14 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(false, test3.equals(test2));
         assertEquals(false, test1.hashCode() == test3.hashCode());
         assertEquals(false, test2.hashCode() == test3.hashCode());
-        
+
         assertEquals(false, test1.equals("Hello"));
         assertEquals(true, test1.equals(new MockInstant()));
         assertEquals(false, test1.equals(new DateTime(TEST_TIME1, GREGORIAN_DEFAULT)));
         assertEquals(true, new DateTime(TEST_TIME1, new MockEqualsChronology()).equals(new DateTime(TEST_TIME1, new MockEqualsChronology())));
         assertEquals(false, new DateTime(TEST_TIME1, new MockEqualsChronology()).equals(new DateTime(TEST_TIME1, ISO_DEFAULT)));
     }
-    
+
     class MockInstant extends AbstractInstant {
         public String toString() {
             return null;
@@ -343,19 +347,19 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(0, test1a.compareTo(test1));
         assertEquals(0, test1.compareTo(test1));
         assertEquals(0, test1a.compareTo(test1a));
-        
+
         DateTime test2 = new DateTime(TEST_TIME2);
         assertEquals(-1, test1.compareTo(test2));
         assertEquals(+1, test2.compareTo(test1));
-        
+
         DateTime test3 = new DateTime(TEST_TIME2, GREGORIAN_PARIS);
         assertEquals(-1, test1.compareTo(test3));
         assertEquals(+1, test3.compareTo(test1));
         assertEquals(0, test3.compareTo(test2));
-        
+
         assertEquals(+1, test2.compareTo(new MockInstant()));
         assertEquals(0, test1.compareTo(new MockInstant()));
-        
+
         try {
             test1.compareTo(null);
             fail();
@@ -365,20 +369,20 @@ public class TestDateTime_Basics extends TestCase {
 //            fail();
 //        } catch (ClassCastException ex) {}
     }
-    
+
     //-----------------------------------------------------------------------
     public void testIsEqual_long() {
         assertEquals(false, new DateTime(TEST_TIME1).isEqual(TEST_TIME2));
         assertEquals(true, new DateTime(TEST_TIME1).isEqual(TEST_TIME1));
         assertEquals(false, new DateTime(TEST_TIME2).isEqual(TEST_TIME1));
     }
-    
+
     public void testIsEqualNow() {
         assertEquals(false, new DateTime(TEST_TIME_NOW - 1).isEqualNow());
         assertEquals(true, new DateTime(TEST_TIME_NOW).isEqualNow());
         assertEquals(false, new DateTime(TEST_TIME_NOW + 1).isEqualNow());
     }
-    
+
     public void testIsEqual_RI() {
         DateTime test1 = new DateTime(TEST_TIME1);
         DateTime test1a = new DateTime(TEST_TIME1);
@@ -386,37 +390,37 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(true, test1a.isEqual(test1));
         assertEquals(true, test1.isEqual(test1));
         assertEquals(true, test1a.isEqual(test1a));
-        
+
         DateTime test2 = new DateTime(TEST_TIME2);
         assertEquals(false, test1.isEqual(test2));
         assertEquals(false, test2.isEqual(test1));
-        
+
         DateTime test3 = new DateTime(TEST_TIME2, GREGORIAN_PARIS);
         assertEquals(false, test1.isEqual(test3));
         assertEquals(false, test3.isEqual(test1));
         assertEquals(true, test3.isEqual(test2));
-        
+
         assertEquals(false, test2.isEqual(new MockInstant()));
         assertEquals(true, test1.isEqual(new MockInstant()));
-        
+
         assertEquals(false, new DateTime(TEST_TIME_NOW + 1).isEqual(null));
         assertEquals(true, new DateTime(TEST_TIME_NOW).isEqual(null));
         assertEquals(false, new DateTime(TEST_TIME_NOW - 1).isEqual(null));
     }
-    
+
     //-----------------------------------------------------------------------
     public void testIsBefore_long() {
         assertEquals(true, new DateTime(TEST_TIME1).isBefore(TEST_TIME2));
         assertEquals(false, new DateTime(TEST_TIME1).isBefore(TEST_TIME1));
         assertEquals(false, new DateTime(TEST_TIME2).isBefore(TEST_TIME1));
     }
-    
+
     public void testIsBeforeNow() {
         assertEquals(true, new DateTime(TEST_TIME_NOW - 1).isBeforeNow());
         assertEquals(false, new DateTime(TEST_TIME_NOW).isBeforeNow());
         assertEquals(false, new DateTime(TEST_TIME_NOW + 1).isBeforeNow());
     }
-    
+
     public void testIsBefore_RI() {
         DateTime test1 = new DateTime(TEST_TIME1);
         DateTime test1a = new DateTime(TEST_TIME1);
@@ -424,37 +428,37 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(false, test1a.isBefore(test1));
         assertEquals(false, test1.isBefore(test1));
         assertEquals(false, test1a.isBefore(test1a));
-        
+
         DateTime test2 = new DateTime(TEST_TIME2);
         assertEquals(true, test1.isBefore(test2));
         assertEquals(false, test2.isBefore(test1));
-        
+
         DateTime test3 = new DateTime(TEST_TIME2, GREGORIAN_PARIS);
         assertEquals(true, test1.isBefore(test3));
         assertEquals(false, test3.isBefore(test1));
         assertEquals(false, test3.isBefore(test2));
-        
+
         assertEquals(false, test2.isBefore(new MockInstant()));
         assertEquals(false, test1.isBefore(new MockInstant()));
-        
+
         assertEquals(false, new DateTime(TEST_TIME_NOW + 1).isBefore(null));
         assertEquals(false, new DateTime(TEST_TIME_NOW).isBefore(null));
         assertEquals(true, new DateTime(TEST_TIME_NOW - 1).isBefore(null));
     }
-    
+
     //-----------------------------------------------------------------------
     public void testIsAfter_long() {
         assertEquals(false, new DateTime(TEST_TIME1).isAfter(TEST_TIME2));
         assertEquals(false, new DateTime(TEST_TIME1).isAfter(TEST_TIME1));
         assertEquals(true, new DateTime(TEST_TIME2).isAfter(TEST_TIME1));
     }
-    
+
     public void testIsAfterNow() {
         assertEquals(false, new DateTime(TEST_TIME_NOW - 1).isAfterNow());
         assertEquals(false, new DateTime(TEST_TIME_NOW).isAfterNow());
         assertEquals(true, new DateTime(TEST_TIME_NOW + 1).isAfterNow());
     }
-    
+
     public void testIsAfter_RI() {
         DateTime test1 = new DateTime(TEST_TIME1);
         DateTime test1a = new DateTime(TEST_TIME1);
@@ -462,39 +466,39 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(false, test1a.isAfter(test1));
         assertEquals(false, test1.isAfter(test1));
         assertEquals(false, test1a.isAfter(test1a));
-        
+
         DateTime test2 = new DateTime(TEST_TIME2);
         assertEquals(false, test1.isAfter(test2));
         assertEquals(true, test2.isAfter(test1));
-        
+
         DateTime test3 = new DateTime(TEST_TIME2, GREGORIAN_PARIS);
         assertEquals(false, test1.isAfter(test3));
         assertEquals(true, test3.isAfter(test1));
         assertEquals(false, test3.isAfter(test2));
-        
+
         assertEquals(true, test2.isAfter(new MockInstant()));
         assertEquals(false, test1.isAfter(new MockInstant()));
-        
+
         assertEquals(true, new DateTime(TEST_TIME_NOW + 1).isAfter(null));
         assertEquals(false, new DateTime(TEST_TIME_NOW).isAfter(null));
         assertEquals(false, new DateTime(TEST_TIME_NOW - 1).isAfter(null));
     }
-    
+
     //-----------------------------------------------------------------------
     public void testSerialization() throws Exception {
         DateTime test = new DateTime(TEST_TIME_NOW);
-        
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(test);
         oos.close();
         byte[] bytes = baos.toByteArray();
-        
+
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);
         DateTime result = (DateTime) ois.readObject();
         ois.close();
-        
+
         assertEquals(test, result);
     }
 
@@ -502,7 +506,7 @@ public class TestDateTime_Basics extends TestCase {
     public void testToString() {
         DateTime test = new DateTime(TEST_TIME_NOW);
         assertEquals("2002-06-09T01:00:00.000+01:00", test.toString());
-        
+
         test = new DateTime(TEST_TIME_NOW, PARIS);
         assertEquals("2002-06-09T02:00:00.000+02:00", test.toString());
     }
@@ -546,7 +550,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime test = new DateTime(TEST_TIME1);
         DateTime result = test.toDateTimeISO();
         assertSame(test, result);
-        
+
         test = new DateTime(TEST_TIME1, ISO_PARIS);
         result = test.toDateTimeISO();
         assertSame(DateTime.class, result.getClass());
@@ -554,7 +558,7 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(test.getMillis(), result.getMillis());
         assertEquals(ISO_PARIS, result.getChronology());
         assertNotSame(test, result);
-        
+
         test = new DateTime(TEST_TIME1, BUDDHIST_DEFAULT);
         result = test.toDateTimeISO();
         assertSame(DateTime.class, result.getClass());
@@ -562,7 +566,7 @@ public class TestDateTime_Basics extends TestCase {
         assertEquals(test.getMillis(), result.getMillis());
         assertEquals(ISO_DEFAULT, result.getChronology());
         assertNotSame(test, result);
-        
+
         test = new DateTime(TEST_TIME1, new MockNullZoneChronology());
         result = test.toDateTimeISO();
         assertSame(DateTime.class, result.getClass());
@@ -753,12 +757,12 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.withMillis(TEST_TIME2);
         assertEquals(TEST_TIME2, result.getMillis());
         assertEquals(test.getChronology(), result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1, GREGORIAN_PARIS);
         result = test.withMillis(TEST_TIME2);
         assertEquals(TEST_TIME2, result.getMillis());
         assertEquals(test.getChronology(), result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1);
         result = test.withMillis(TEST_TIME1);
         assertSame(test, result);
@@ -769,17 +773,17 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.withChronology(GREGORIAN_PARIS);
         assertEquals(test.getMillis(), result.getMillis());
         assertEquals(GREGORIAN_PARIS, result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1, GREGORIAN_PARIS);
         result = test.withChronology(null);
         assertEquals(test.getMillis(), result.getMillis());
         assertEquals(ISO_DEFAULT, result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1);
         result = test.withChronology(null);
         assertEquals(test.getMillis(), result.getMillis());
         assertEquals(ISO_DEFAULT, result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1);
         result = test.withChronology(ISO_DEFAULT);
         assertSame(test, result);
@@ -790,12 +794,12 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.withZone(PARIS);
         assertEquals(test.getMillis(), result.getMillis());
         assertEquals(ISO_PARIS, result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1, GREGORIAN_PARIS);
         result = test.withZone(null);
         assertEquals(test.getMillis(), result.getMillis());
         assertEquals(GREGORIAN_DEFAULT, result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1);
         result = test.withZone(null);
         assertSame(test, result);
@@ -806,39 +810,39 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.withZoneRetainFields(PARIS);
         assertEquals(test.getMillis() - DateTimeConstants.MILLIS_PER_HOUR, result.getMillis());
         assertEquals(ISO_PARIS, result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1);
         result = test.withZoneRetainFields(LONDON);
         assertSame(test, result);
-        
+
         test = new DateTime(TEST_TIME1);
         result = test.withZoneRetainFields(null);
         assertSame(test, result);
-        
+
         test = new DateTime(TEST_TIME1, GREGORIAN_PARIS);
         result = test.withZoneRetainFields(null);
         assertEquals(test.getMillis() + DateTimeConstants.MILLIS_PER_HOUR, result.getMillis());
         assertEquals(GREGORIAN_DEFAULT, result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1, new MockNullZoneChronology());
         result = test.withZoneRetainFields(LONDON);
         assertSame(test, result);
     }
-    
+
     //-----------------------------------------------------------------------
     public void testWithDate_int_int_int() {
         DateTime test = new DateTime(2002, 4, 5, 1, 2, 3, 4, ISO_UTC);
         DateTime result = test.withDate(2003, 5, 6);
         DateTime expected = new DateTime(2003, 5, 6, 1, 2, 3, 4, ISO_UTC);
         assertEquals(expected, result);
-        
+
         test = new DateTime(TEST_TIME1);
         try {
             test.withDate(2003, 13, 1);
             fail();
         } catch (IllegalArgumentException ex) {}
     }
-    
+
     public void testWithDate_int_int_int_toDST1() {
         // 2010-03-28T02:55 is DST time, need to change to 03:55
         DateTime test = new DateTime(2015, 1, 10, 2, 55, 0, 0, ISO_PARIS);
@@ -846,7 +850,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime expected = new DateTime(2010, 3, 28, 3, 55, 0, 0, ISO_PARIS);
         assertEquals(expected, result);
     }
-    
+
     public void testWithDate_int_int_int_toDST2() {
         // 2010-03-28T02:55 is DST time, need to change to 03:55
         DateTime test = new DateTime(2015, 1, 28, 2, 55, 0, 0, ISO_PARIS);
@@ -854,7 +858,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime expected = new DateTime(2010, 3, 28, 3, 55, 0, 0, ISO_PARIS);
         assertEquals(expected, result);
     }
-    
+
     public void testWithDate_int_int_int_affectedByDST() {
         // 2010-03-28T02:55 is DST time, need to avoid time being changed to 03:55
         DateTime test = new DateTime(2015, 1, 28, 2, 55, 0, 0, ISO_PARIS);
@@ -862,34 +866,34 @@ public class TestDateTime_Basics extends TestCase {
         DateTime expected = new DateTime(2010, 3, 10, 2, 55, 0, 0, ISO_PARIS);
         assertEquals(expected, result);
     }
-    
+
     public void testWithDate_LocalDate() {
         DateTime test = new DateTime(2002, 4, 5, 1, 2, 3, 4, ISO_UTC);
         DateTime result = test.withDate(new LocalDate(2003, 5, 6));
         DateTime expected = new DateTime(2003, 5, 6, 1, 2, 3, 4, ISO_UTC);
         assertEquals(expected, result);
-        
+
         test = new DateTime(TEST_TIME1);
         try {
             test.withDate(new LocalDate(2003, 13, 1));
             fail();
         } catch (IllegalArgumentException ex) {}
     }
-    
+
     //-----------------------------------------------------------------------
     public void testWithTime_int_int_int_int() {
         DateTime test = new DateTime(TEST_TIME1 - 12345L, BUDDHIST_UTC);
         DateTime result = test.withTime(12, 24, 0, 0);
         assertEquals(TEST_TIME1, result.getMillis());
         assertEquals(BUDDHIST_UTC, result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1);
         try {
             test.withTime(25, 1, 1, 1);
             fail();
         } catch (IllegalArgumentException ex) {}
     }
-    
+
     public void testWithTime_int_int_int_int_toDST() {
         // 2010-03-28T02:55 is DST time, need to change to 03:55
         DateTime test = new DateTime(2010, 3, 28, 0, 0, 0, 0, ISO_PARIS);
@@ -897,37 +901,37 @@ public class TestDateTime_Basics extends TestCase {
         DateTime expected = new DateTime(2010, 3, 28, 3, 55, 0, 0, ISO_PARIS);
         assertEquals(expected, result);
     }
-    
+
     public void testWithTime_LocalTime() {
         DateTime test = new DateTime(TEST_TIME1 - 12345L, BUDDHIST_UTC);
         DateTime result = test.withTime(new LocalTime(12, 24, 0, 0));
         assertEquals(TEST_TIME1, result.getMillis());
         assertEquals(BUDDHIST_UTC, result.getChronology());
-        
+
         test = new DateTime(TEST_TIME1);
         try {
             test.withTime(new LocalTime(25, 1, 1, 1));
             fail();
         } catch (IllegalArgumentException ex) {}
     }
-    
+
     @SuppressWarnings("deprecation")
     public void testWithFields_RPartial() {
         DateTime test = new DateTime(2004, 5, 6, 7, 8, 9, 0);
         DateTime result = test.withFields(new YearMonthDay(2003, 4, 5));
         DateTime expected = new DateTime(2003, 4, 5, 7, 8, 9, 0);
         assertEquals(expected, result);
-        
+
         test = new DateTime(TEST_TIME1);
         result = test.withFields(null);
         assertSame(test, result);
     }
-    
+
     //-----------------------------------------------------------------------
     public void testWithField1() {
         DateTime test = new DateTime(2004, 6, 9, 0, 0, 0, 0);
         DateTime result = test.withField(DateTimeFieldType.year(), 2006);
-        
+
         assertEquals(new DateTime(2004, 6, 9, 0, 0, 0, 0), test);
         assertEquals(new DateTime(2006, 6, 9, 0, 0, 0, 0), result);
     }
@@ -944,7 +948,7 @@ public class TestDateTime_Basics extends TestCase {
     public void testWithFieldAdded1() {
         DateTime test = new DateTime(2004, 6, 9, 0, 0, 0, 0);
         DateTime result = test.withFieldAdded(DurationFieldType.years(), 6);
-        
+
         assertEquals(new DateTime(2004, 6, 9, 0, 0, 0, 0), test);
         assertEquals(new DateTime(2010, 6, 9, 0, 0, 0, 0), result);
     }
@@ -977,87 +981,87 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.withDurationAdded(123456789L, 1);
         DateTime expected = new DateTime(TEST_TIME1 + 123456789L, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.withDurationAdded(123456789L, 0);
         assertSame(test, result);
-        
+
         result = test.withDurationAdded(123456789L, 2);
         expected = new DateTime(TEST_TIME1 + (2L * 123456789L), BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.withDurationAdded(123456789L, -3);
         expected = new DateTime(TEST_TIME1 - (3L * 123456789L), BUDDHIST_DEFAULT);
         assertEquals(expected, result);
     }
-    
+
     //-----------------------------------------------------------------------
     public void testWithDurationAdded_RD_int() {
         DateTime test = new DateTime(TEST_TIME1, BUDDHIST_DEFAULT);
         DateTime result = test.withDurationAdded(new Duration(123456789L), 1);
         DateTime expected = new DateTime(TEST_TIME1 + 123456789L, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.withDurationAdded(null, 1);
         assertSame(test, result);
-        
+
         result = test.withDurationAdded(new Duration(123456789L), 0);
         assertSame(test, result);
-        
+
         result = test.withDurationAdded(new Duration(123456789L), 2);
         expected = new DateTime(TEST_TIME1 + (2L * 123456789L), BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.withDurationAdded(new Duration(123456789L), -3);
         expected = new DateTime(TEST_TIME1 - (3L * 123456789L), BUDDHIST_DEFAULT);
         assertEquals(expected, result);
     }
-    
+
     //-----------------------------------------------------------------------
     public void testWithDurationAdded_RP_int() {
         DateTime test = new DateTime(2002, 5, 3, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         DateTime result = test.withPeriodAdded(new Period(1, 2, 3, 4, 5, 6, 7, 8), 1);
         DateTime expected = new DateTime(2003, 7, 28, 6, 8, 10, 12, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.withPeriodAdded(null, 1);
         assertSame(test, result);
-        
+
         result = test.withPeriodAdded(new Period(1, 2, 3, 4, 5, 6, 7, 8), 0);
         assertSame(test, result);
-        
+
         result = test.withPeriodAdded(new Period(1, 2, 0, 4, 5, 6, 7, 8), 3);
         expected = new DateTime(2005, 11, 15, 16, 20, 24, 28, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.withPeriodAdded(new Period(1, 2, 0, 1, 1, 2, 3, 4), -1);
         expected = new DateTime(2001, 3, 2, 0, 0, 0, 0, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
     }
 
-    //-----------------------------------------------------------------------    
+    //-----------------------------------------------------------------------
     public void testPlus_long() {
         DateTime test = new DateTime(TEST_TIME1, BUDDHIST_DEFAULT);
         DateTime result = test.plus(123456789L);
         DateTime expected = new DateTime(TEST_TIME1 + 123456789L, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
     }
-    
+
     public void testPlus_RD() {
         DateTime test = new DateTime(TEST_TIME1, BUDDHIST_DEFAULT);
         DateTime result = test.plus(new Duration(123456789L));
         DateTime expected = new DateTime(TEST_TIME1 + 123456789L, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.plus((ReadableDuration) null);
         assertSame(test, result);
     }
-    
+
     public void testPlus_RP() {
         DateTime test = new DateTime(2002, 5, 3, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         DateTime result = test.plus(new Period(1, 2, 3, 4, 5, 6, 7, 8));
         DateTime expected = new DateTime(2003, 7, 28, 6, 8, 10, 12, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.plus((ReadablePeriod) null);
         assertSame(test, result);
     }
@@ -1067,7 +1071,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.plusYears(1);
         DateTime expected = new DateTime(2003, 5, 3, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.plusYears(0);
         assertSame(test, result);
     }
@@ -1077,7 +1081,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.plusMonths(1);
         DateTime expected = new DateTime(2002, 6, 3, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.plusMonths(0);
         assertSame(test, result);
     }
@@ -1087,7 +1091,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.plusWeeks(1);
         DateTime expected = new DateTime(2002, 5, 10, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.plusWeeks(0);
         assertSame(test, result);
     }
@@ -1097,7 +1101,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.plusDays(1);
         DateTime expected = new DateTime(2002, 5, 4, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.plusDays(0);
         assertSame(test, result);
     }
@@ -1107,7 +1111,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.plusHours(1);
         DateTime expected = new DateTime(2002, 5, 3, 2, 2, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.plusHours(0);
         assertSame(test, result);
     }
@@ -1117,7 +1121,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.plusMinutes(1);
         DateTime expected = new DateTime(2002, 5, 3, 1, 3, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.plusMinutes(0);
         assertSame(test, result);
     }
@@ -1127,7 +1131,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.plusSeconds(1);
         DateTime expected = new DateTime(2002, 5, 3, 1, 2, 4, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.plusSeconds(0);
         assertSame(test, result);
     }
@@ -1137,35 +1141,35 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.plusMillis(1);
         DateTime expected = new DateTime(2002, 5, 3, 1, 2, 3, 5, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.plusMillis(0);
         assertSame(test, result);
     }
 
-    //-----------------------------------------------------------------------    
+    //-----------------------------------------------------------------------
     public void testMinus_long() {
         DateTime test = new DateTime(TEST_TIME1, BUDDHIST_DEFAULT);
         DateTime result = test.minus(123456789L);
         DateTime expected = new DateTime(TEST_TIME1 - 123456789L, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
     }
-    
+
     public void testMinus_RD() {
         DateTime test = new DateTime(TEST_TIME1, BUDDHIST_DEFAULT);
         DateTime result = test.minus(new Duration(123456789L));
         DateTime expected = new DateTime(TEST_TIME1 - 123456789L, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.minus((ReadableDuration) null);
         assertSame(test, result);
     }
-    
+
     public void testMinus_RP() {
         DateTime test = new DateTime(2002, 5, 3, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         DateTime result = test.minus(new Period(1, 1, 1, 1, 1, 1, 1, 1));
         DateTime expected = new DateTime(2001, 3, 26, 0, 1, 2, 3, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.minus((ReadablePeriod) null);
         assertSame(test, result);
     }
@@ -1175,7 +1179,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.minusYears(1);
         DateTime expected = new DateTime(2001, 5, 3, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.minusYears(0);
         assertSame(test, result);
     }
@@ -1185,7 +1189,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.minusMonths(1);
         DateTime expected = new DateTime(2002, 4, 3, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.minusMonths(0);
         assertSame(test, result);
     }
@@ -1195,7 +1199,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.minusWeeks(1);
         DateTime expected = new DateTime(2002, 4, 26, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.minusWeeks(0);
         assertSame(test, result);
     }
@@ -1205,7 +1209,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.minusDays(1);
         DateTime expected = new DateTime(2002, 5, 2, 1, 2, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.minusDays(0);
         assertSame(test, result);
     }
@@ -1215,7 +1219,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.minusHours(1);
         DateTime expected = new DateTime(2002, 5, 3, 0, 2, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.minusHours(0);
         assertSame(test, result);
     }
@@ -1225,7 +1229,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.minusMinutes(1);
         DateTime expected = new DateTime(2002, 5, 3, 1, 1, 3, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.minusMinutes(0);
         assertSame(test, result);
     }
@@ -1235,7 +1239,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.minusSeconds(1);
         DateTime expected = new DateTime(2002, 5, 3, 1, 2, 2, 4, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.minusSeconds(0);
         assertSame(test, result);
     }
@@ -1245,7 +1249,7 @@ public class TestDateTime_Basics extends TestCase {
         DateTime result = test.minusMillis(1);
         DateTime expected = new DateTime(2002, 5, 3, 1, 2, 3, 3, BUDDHIST_DEFAULT);
         assertEquals(expected, result);
-        
+
         result = test.minusMillis(0);
         assertSame(test, result);
     }
@@ -1283,6 +1287,7 @@ public class TestDateTime_Basics extends TestCase {
     private void check(DateTime test, int year, int month, int day, int hour, int min, int sec, int mil) {
         assertEquals(year, test.getYear());
         assertEquals(month, test.getMonthOfYear());
+        assertEquals((month  - 1)/ 3 + 1, test.getQuarterOfYear());
         assertEquals(day, test.getDayOfMonth());
         assertEquals(hour, test.getHourOfDay());
         assertEquals(min, test.getMinuteOfHour());

--- a/src/test/java/org/joda/time/TestDateTime_Basics.java
+++ b/src/test/java/org/joda/time/TestDateTime_Basics.java
@@ -256,7 +256,18 @@ public class TestDateTime_Basics extends TestCase {
     public void testWithers() {
         DateTime test = new DateTime(1970, 6, 9, 10, 20, 30, 40, GJ_DEFAULT);
         check(test.withYear(2000), 2000, 6, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(1), 1970, 1, 9, 10, 20, 30, 40);
         check(test.withMonthOfYear(2), 1970, 2, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(3), 1970, 3, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(4), 1970, 4, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(5), 1970, 5, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(6), 1970, 6, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(7), 1970, 7, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(8), 1970, 8, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(9), 1970, 9, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(10), 1970, 10, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(11), 1970, 11, 9, 10, 20, 30, 40);
+        check(test.withMonthOfYear(12), 1970, 12, 9, 10, 20, 30, 40);
         check(test.withDayOfMonth(2), 1970, 6, 2, 10, 20, 30, 40);
         check(test.withDayOfYear(6), 1970, 1, 6, 10, 20, 30, 40);
         check(test.withDayOfWeek(6), 1970, 6, 13, 10, 20, 30, 40);

--- a/src/test/java/org/joda/time/chrono/TestISOChronology.java
+++ b/src/test/java/org/joda/time/chrono/TestISOChronology.java
@@ -47,8 +47,8 @@ public class TestISOChronology extends TestCase {
     private static final DateTimeZone LONDON = DateTimeZone.forID("Europe/London");
     private static final DateTimeZone TOKYO = DateTimeZone.forID("Asia/Tokyo");
 
-    long y2002days = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 
-                     366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 
+    long y2002days = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
+                     366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 +
                      365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
                      366 + 365;
     // 2002-06-09
@@ -156,7 +156,7 @@ public class TestISOChronology extends TestCase {
         assertEquals("minutes", iso.minutes().getName());
         assertEquals("seconds", iso.seconds().getName());
         assertEquals("millis", iso.millis().getName());
-        
+
         assertEquals(false, iso.eras().isSupported());
         assertEquals(true, iso.centuries().isSupported());
         assertEquals(true, iso.years().isSupported());
@@ -169,7 +169,7 @@ public class TestISOChronology extends TestCase {
         assertEquals(true, iso.minutes().isSupported());
         assertEquals(true, iso.seconds().isSupported());
         assertEquals(true, iso.millis().isSupported());
-        
+
         assertEquals(false, iso.centuries().isPrecise());
         assertEquals(false, iso.years().isPrecise());
         assertEquals(false, iso.weekyears().isPrecise());
@@ -181,7 +181,7 @@ public class TestISOChronology extends TestCase {
         assertEquals(true, iso.minutes().isPrecise());
         assertEquals(true, iso.seconds().isPrecise());
         assertEquals(true, iso.millis().isPrecise());
-        
+
         final ISOChronology isoUTC = ISOChronology.getInstanceUTC();
         assertEquals(false, isoUTC.centuries().isPrecise());
         assertEquals(false, isoUTC.years().isPrecise());
@@ -194,7 +194,7 @@ public class TestISOChronology extends TestCase {
         assertEquals(true, isoUTC.minutes().isPrecise());
         assertEquals(true, isoUTC.seconds().isPrecise());
         assertEquals(true, isoUTC.millis().isPrecise());
-        
+
         final DateTimeZone gmt = DateTimeZone.forID("Etc/GMT");
         final ISOChronology isoGMT = ISOChronology.getInstance(gmt);
         assertEquals(false, isoGMT.centuries().isPrecise());
@@ -208,7 +208,7 @@ public class TestISOChronology extends TestCase {
         assertEquals(true, isoGMT.minutes().isPrecise());
         assertEquals(true, isoGMT.seconds().isPrecise());
         assertEquals(true, isoGMT.millis().isPrecise());
-        
+
         final DateTimeZone offset = DateTimeZone.forOffsetHours(1);
         final ISOChronology isoOffset1 = ISOChronology.getInstance(offset);
         assertEquals(false, isoOffset1.centuries().isPrecise());
@@ -232,26 +232,28 @@ public class TestISOChronology extends TestCase {
         assertEquals("yearOfEra", iso.yearOfEra().getName());
         assertEquals("year", iso.year().getName());
         assertEquals("monthOfYear", iso.monthOfYear().getName());
+        //assertEquals("quarterOfYear", iso.quarterOfYear().getName());
         assertEquals("weekyearOfCentury", iso.weekyearOfCentury().getName());
         assertEquals("weekyear", iso.weekyear().getName());
         assertEquals("weekOfWeekyear", iso.weekOfWeekyear().getName());
         assertEquals("dayOfYear", iso.dayOfYear().getName());
         assertEquals("dayOfMonth", iso.dayOfMonth().getName());
         assertEquals("dayOfWeek", iso.dayOfWeek().getName());
-        
+
         assertEquals(true, iso.era().isSupported());
         assertEquals(true, iso.centuryOfEra().isSupported());
         assertEquals(true, iso.yearOfCentury().isSupported());
         assertEquals(true, iso.yearOfEra().isSupported());
         assertEquals(true, iso.year().isSupported());
         assertEquals(true, iso.monthOfYear().isSupported());
+        assertEquals(true, iso.quarterOfYear().isSupported());
         assertEquals(true, iso.weekyearOfCentury().isSupported());
         assertEquals(true, iso.weekyear().isSupported());
         assertEquals(true, iso.weekOfWeekyear().isSupported());
         assertEquals(true, iso.dayOfYear().isSupported());
         assertEquals(true, iso.dayOfMonth().isSupported());
         assertEquals(true, iso.dayOfWeek().isSupported());
-        
+
         assertEquals(iso.eras(), iso.era().getDurationField());
         assertEquals(iso.centuries(), iso.centuryOfEra().getDurationField());
         assertEquals(iso.years(), iso.yearOfCentury().getDurationField());
@@ -264,7 +266,7 @@ public class TestISOChronology extends TestCase {
         assertEquals(iso.days(), iso.dayOfYear().getDurationField());
         assertEquals(iso.days(), iso.dayOfMonth().getDurationField());
         assertEquals(iso.days(), iso.dayOfWeek().getDurationField());
-        
+
         assertEquals(null, iso.era().getRangeDurationField());
         assertEquals(iso.eras(), iso.centuryOfEra().getRangeDurationField());
         assertEquals(iso.centuries(), iso.yearOfCentury().getRangeDurationField());
@@ -292,7 +294,7 @@ public class TestISOChronology extends TestCase {
         assertEquals("secondOfMinute", iso.secondOfMinute().getName());
         assertEquals("millisOfDay", iso.millisOfDay().getName());
         assertEquals("millisOfSecond", iso.millisOfSecond().getName());
-        
+
         assertEquals(true, iso.halfdayOfDay().isSupported());
         assertEquals(true, iso.clockhourOfHalfday().isSupported());
         assertEquals(true, iso.hourOfHalfday().isSupported());
@@ -317,7 +319,7 @@ public class TestISOChronology extends TestCase {
         assertEquals(maxYear, start.getYear());
         assertEquals(maxYear, end.getYear());
         long delta = end.getMillis() - start.getMillis();
-        long expectedDelta = 
+        long expectedDelta =
             (start.year().isLeap() ? 366L : 365L) * DateTimeConstants.MILLIS_PER_DAY - 1;
         assertEquals(expectedDelta, delta);
 
@@ -350,7 +352,7 @@ public class TestISOChronology extends TestCase {
         assertEquals(minYear, start.getYear());
         assertEquals(minYear, end.getYear());
         long delta = end.getMillis() - start.getMillis();
-        long expectedDelta = 
+        long expectedDelta =
             (start.year().isLeap() ? 366L : 365L) * DateTimeConstants.MILLIS_PER_DAY - 1;
         assertEquals(expectedDelta, delta);
 
@@ -416,7 +418,7 @@ public class TestISOChronology extends TestCase {
         DurationField field = type.getField(ISOChronology.getInstanceUTC());
         int diff = field.getDifference(dtEnd.getMillis(), dtStart.getMillis());
         assertEquals(amt, diff);
-        
+
         if (type == DurationFieldType.years() ||
             type == DurationFieldType.months() ||
             type == DurationFieldType.days()) {

--- a/src/test/java/org/joda/time/format/TestDateTimeFormat.java
+++ b/src/test/java/org/joda/time/format/TestDateTimeFormat.java
@@ -43,8 +43,8 @@ public class TestDateTimeFormat extends TestCase {
     private static final DateTimeZone TOKYO = DateTimeZone.forID("Asia/Tokyo");
     private static final DateTimeZone NEWYORK = DateTimeZone.forID("America/New_York");
 
-    long y2002days = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 
-                     366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 
+    long y2002days = 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
+                     366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 +
                      365 + 365 + 366 + 365 + 365 + 365 + 366 + 365 + 365 + 365 +
                      366 + 365;
     // 2002-06-09
@@ -100,10 +100,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("G").withLocale(Locale.UK);
         assertEquals(dt.toString(), "AD", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "AD", f.print(dt));
-        
+
         dt = dt.withZone(PARIS);
         assertEquals(dt.toString(), "AD", f.print(dt));
     }
@@ -113,13 +113,13 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("C").withLocale(Locale.UK);
         assertEquals(dt.toString(), "20", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "20", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "20", f.print(dt));
-        
+
         dt = new DateTime(-123, 6, 9, 10, 20, 30, 40, UTC);
         assertEquals(dt.toString(), "1", f.print(dt));
     }
@@ -129,34 +129,34 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("Y").withLocale(Locale.UK);
         assertEquals(dt.toString(), "2004", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "2004", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "2004", f.print(dt));
-        
+
         dt = new DateTime(-123, 6, 9, 10, 20, 30, 40, UTC);
         assertEquals(dt.toString(), "124", f.print(dt));  // 124th year of BCE
-    }        
+    }
 
     public void testFormat_yearOfEra_twoDigit() {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("YY").withLocale(Locale.UK);
         assertEquals(dt.toString(), "04", f.print(dt));
-        
+
         dt = new DateTime(-123, 6, 9, 10, 20, 30, 40, UTC);
         assertEquals(dt.toString(), "23", f.print(dt));
-        
+
         // current time set to 2002-06-09
         f = f.withZoneUTC();
         DateTime expect = null;
         expect = new DateTime(2004, 1, 1, 0, 0, 0, 0, UTC);
         assertEquals(expect, f.parseDateTime("04"));
-        
+
         expect = new DateTime(1922, 1, 1, 0, 0, 0, 0, UTC);
         assertEquals(expect, f.parseDateTime("22"));
-        
+
         expect = new DateTime(2021, 1, 1, 0, 0, 0, 0, UTC);
         assertEquals(expect, f.parseDateTime("21"));
 
@@ -203,20 +203,20 @@ public class TestDateTimeFormat extends TestCase {
         dt = new DateTime(-2005, 10, 1, 0, 0, 0, 0, chrono);
         assertEquals(dt, f.parseDateTime("2005-10 BC"));
         assertEquals(dt, f.parseDateTime("2005-10 BCE"));
-    }        
+    }
 
     //-----------------------------------------------------------------------
     public void testFormat_year() {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("y").withLocale(Locale.UK);
         assertEquals(dt.toString(), "2004", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "2004", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "2004", f.print(dt));
-        
+
         dt = new DateTime(-123, 6, 9, 10, 20, 30, 40, UTC);
         assertEquals(dt.toString(), "-123", f.print(dt));
 
@@ -236,19 +236,19 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("yy").withLocale(Locale.UK);
         assertEquals(dt.toString(), "04", f.print(dt));
-        
+
         dt = new DateTime(-123, 6, 9, 10, 20, 30, 40, UTC);
         assertEquals(dt.toString(), "23", f.print(dt));
-        
+
         // current time set to 2002-06-09
         f = f.withZoneUTC();
         DateTime expect = null;
         expect = new DateTime(2004, 1, 1, 0, 0, 0, 0, UTC);
         assertEquals(expect, f.parseDateTime("04"));
-        
+
         expect = new DateTime(1922, 1, 1, 0, 0, 0, 0, UTC);
         assertEquals(expect, f.parseDateTime("22"));
-        
+
         expect = new DateTime(2021, 1, 1, 0, 0, 0, 0, UTC);
         assertEquals(expect, f.parseDateTime("21"));
 
@@ -351,11 +351,11 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(278004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("yyyy");
         assertEquals(dt.toString(), "278004", f.print(dt));
-        
+
         // for coverage
         f = DateTimeFormat.forPattern("yyyyMMdd");
         assertEquals(dt.toString(), "2780040609", f.print(dt));
-        
+
         // for coverage
         f = DateTimeFormat.forPattern("yyyyddMM");
         assertEquals(dt.toString(), "2780040906", f.print(dt));
@@ -366,13 +366,13 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("x").withLocale(Locale.UK);
         assertEquals(dt.toString(), "2004", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "2004", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "2004", f.print(dt));
-        
+
         dt = new DateTime(-123, 6, 9, 10, 20, 30, 40, UTC);
         assertEquals(dt.toString(), "-123", f.print(dt));
     }
@@ -381,19 +381,19 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("xx").withLocale(Locale.UK);
         assertEquals(dt.toString(), "04", f.print(dt));
-        
+
         dt = new DateTime(-123, 6, 9, 10, 20, 30, 40, UTC);
         assertEquals(dt.toString(), "23", f.print(dt));
-        
+
         // current time set to 2002-06-09
         f = f.withZoneUTC();
         DateTime expect = null;
         expect = new DateTime(2003, 12, 29, 0, 0, 0, 0, UTC);
         assertEquals(expect, f.parseDateTime("04"));
-        
+
         expect = new DateTime(1922, 1, 2, 0, 0, 0, 0, UTC);
         assertEquals(expect, f.parseDateTime("22"));
-        
+
         expect = new DateTime(2021, 1, 4, 0, 0, 0, 0, UTC);
         assertEquals(expect, f.parseDateTime("21"));
 
@@ -497,10 +497,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("w").withLocale(Locale.UK);
         assertEquals(dt.toString(), "24", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "24", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "24", f.print(dt));
     }
@@ -510,10 +510,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("e").withLocale(Locale.UK);
         assertEquals(dt.toString(), "3", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "3", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "3", f.print(dt));
     }
@@ -523,13 +523,13 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("E").withLocale(Locale.UK);
         assertEquals(dt.toString(), "Wed", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "Wed", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "Wed", f.print(dt));
-        
+
         f = f.withLocale(Locale.FRENCH);
         assertEquals(dt.toString(), "mer.", f.print(dt));
     }
@@ -539,13 +539,13 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("EEEE").withLocale(Locale.UK);
         assertEquals(dt.toString(), "Wednesday", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "Wednesday", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "Wednesday", f.print(dt));
-        
+
         f = f.withLocale(Locale.FRENCH);
         assertEquals(dt.toString(), "mercredi", f.print(dt));
     }
@@ -555,10 +555,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("D").withLocale(Locale.UK);
         assertEquals(dt.toString(), "161", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "161", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "161", f.print(dt));
     }
@@ -568,26 +568,40 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("M").withLocale(Locale.UK);
         assertEquals(dt.toString(), "6", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "6", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "6", f.print(dt));
     }
+
+    //-----------------------------------------------------------------------
+    public void testFormat_quarterOfYear() {
+        DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
+        DateTimeFormatter f = DateTimeFormat.forPattern("Q").withLocale(Locale.UK);
+        assertEquals(dt.toString(), "2", f.print(dt));
+
+        dt = dt.withZone(NEWYORK);
+        assertEquals(dt.toString(), "2", f.print(dt));
+
+        dt = dt.withZone(TOKYO);
+        assertEquals(dt.toString(), "2", f.print(dt));
+    }
+
 
     //-----------------------------------------------------------------------
     public void testFormat_monthOfYearShortText() {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("MMM").withLocale(Locale.UK);
         assertEquals(dt.toString(), "Jun", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "Jun", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "Jun", f.print(dt));
-        
+
         f = f.withLocale(Locale.FRENCH);
         assertEquals(dt.toString(), "juin", f.print(dt));
     }
@@ -597,13 +611,13 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("MMMM").withLocale(Locale.UK);
         assertEquals(dt.toString(), "June", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "June", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "June", f.print(dt));
-        
+
         f = f.withLocale(Locale.FRENCH);
         assertEquals(dt.toString(), "juin", f.print(dt));
     }
@@ -613,10 +627,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("d").withLocale(Locale.UK);
         assertEquals(dt.toString(), "9", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "9", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "9", f.print(dt));
     }
@@ -626,10 +640,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("a").withLocale(Locale.UK);
         assertEquals(dt.toString(), "AM", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "AM", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "PM", f.print(dt));
     }
@@ -639,13 +653,13 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("K").withLocale(Locale.UK);
         assertEquals(dt.toString(), "10", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "6", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "7", f.print(dt));
-        
+
         dt = new DateTime(2004, 6, 9, 0, 0, 0, 0, UTC);
         assertEquals(dt.toString(), "0", f.print(dt));
     }
@@ -655,13 +669,13 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("h").withLocale(Locale.UK);
         assertEquals(dt.toString(), "10", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "6", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "7", f.print(dt));
-        
+
         dt = new DateTime(2004, 6, 9, 0, 0, 0, 0, UTC);
         assertEquals(dt.toString(), "12", f.print(dt));
     }
@@ -671,13 +685,13 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("H").withLocale(Locale.UK);
         assertEquals(dt.toString(), "10", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "6", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "19", f.print(dt));
-        
+
         dt = new DateTime(2004, 6, 9, 0, 0, 0, 0, UTC);
         assertEquals(dt.toString(), "0", f.print(dt));
     }
@@ -687,13 +701,13 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("k").withLocale(Locale.UK);
         assertEquals(dt.toString(), "10", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "6", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "19", f.print(dt));
-        
+
         dt = new DateTime(2004, 6, 9, 0, 0, 0, 0, UTC);
         assertEquals(dt.toString(), "24", f.print(dt));
     }
@@ -703,10 +717,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("m").withLocale(Locale.UK);
         assertEquals(dt.toString(), "20", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "20", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "20", f.print(dt));
     }
@@ -716,10 +730,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("s").withLocale(Locale.UK);
         assertEquals(dt.toString(), "30", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "30", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "30", f.print(dt));
     }
@@ -729,10 +743,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("SSS").withLocale(Locale.UK);
         assertEquals(dt.toString(), "040", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "040", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "040", f.print(dt));
     }
@@ -742,10 +756,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("SSSSSS").withLocale(Locale.UK);
         assertEquals(dt.toString(), "040000", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "040000", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "040000", f.print(dt));
     }
@@ -755,10 +769,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("z").withLocale(Locale.UK);
         assertEquals(dt.toString(), "UTC", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "EDT", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "JST", f.print(dt));
     }
@@ -767,10 +781,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("zzzz").withLocale(Locale.UK);
         assertEquals(dt.toString(), "Coordinated Universal Time", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "Eastern Daylight Time", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "Japan Standard Time", f.print(dt));
     }
@@ -780,10 +794,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("Z").withLocale(Locale.UK);
         assertEquals(dt.toString(), "+0000", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "-0400", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "+0900", f.print(dt));
     }
@@ -792,10 +806,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("ZZ").withLocale(Locale.UK);
         assertEquals(dt.toString(), "+00:00", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "-04:00", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "+09:00", f.print(dt));
     }
@@ -804,10 +818,10 @@ public class TestDateTimeFormat extends TestCase {
         DateTime dt = new DateTime(2004, 6, 9, 10, 20, 30, 40, UTC);
         DateTimeFormatter f = DateTimeFormat.forPattern("ZZZ").withLocale(Locale.UK);
         assertEquals(dt.toString(), "UTC", f.print(dt));
-        
+
         dt = dt.withZone(NEWYORK);
         assertEquals(dt.toString(), "America/New_York", f.print(dt));
-        
+
         dt = dt.withZone(TOKYO);
         assertEquals(dt.toString(), "Asia/Tokyo", f.print(dt));
     }
@@ -865,26 +879,26 @@ public class TestDateTimeFormat extends TestCase {
     //-----------------------------------------------------------------------
     public void testParse_pivotYear() {
         DateTimeFormatter dateFormatter = DateTimeFormat.forPattern("dd.MM.yy").withPivotYear(2050).withZoneUTC();
-        
+
         DateTime date = dateFormatter.parseDateTime("25.12.15");
         assertEquals(date.getYear(), 2015);
-        
+
         date = dateFormatter.parseDateTime("25.12.00");
         assertEquals(date.getYear(), 2000);
-        
+
         date = dateFormatter.parseDateTime("25.12.99");
         assertEquals(date.getYear(), 2099);
     }
 
     public void testParse_pivotYear_ignored4DigitYear() {
         DateTimeFormatter dateFormatter = DateTimeFormat.forPattern("dd.MM.yyyy").withPivotYear(2050).withZoneUTC();
-        
+
         DateTime date = dateFormatter.parseDateTime("25.12.15");
         assertEquals(date.getYear(), 15);
-        
+
         date = dateFormatter.parseDateTime("25.12.00");
         assertEquals(date.getYear(), 0);
-        
+
         date = dateFormatter.parseDateTime("25.12.99");
         assertEquals(date.getYear(), 99);
     }
@@ -893,7 +907,7 @@ public class TestDateTimeFormat extends TestCase {
     public void testFormatParse_textMonthJanShort_UK() {
         DateTimeFormatter dateFormatter = DateTimeFormat.forPattern("dd MMM yyyy")
             .withLocale(Locale.UK).withZoneUTC();
-        
+
         String str = new DateTime(2007, 1, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals(str, "23 Jan 2007");
         DateTime date = dateFormatter.parseDateTime(str);
@@ -917,7 +931,7 @@ public class TestDateTimeFormat extends TestCase {
     public void testParse_textMonthJanLong_UK() {
         DateTimeFormatter dateFormatter = DateTimeFormat.forPattern("dd MMM yyyy")
             .withLocale(Locale.UK).withZoneUTC();
-        
+
         DateTime date = dateFormatter.parseDateTime("23 January 2007");
         check(date, 2007, 1, 23);
     }
@@ -939,7 +953,7 @@ public class TestDateTimeFormat extends TestCase {
     public void testFormatParse_textMonthJanShort_France() {
         DateTimeFormatter dateFormatter = DateTimeFormat.forPattern("dd MMM yyyy")
             .withLocale(Locale.FRANCE).withZoneUTC();
-        
+
         String str = new DateTime(2007, 1, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("23 janv. 2007", str);
         DateTime date = dateFormatter.parseDateTime(str);
@@ -949,7 +963,7 @@ public class TestDateTimeFormat extends TestCase {
     public void testFormatParse_textMonthJanLong_France() {
         DateTimeFormatter dateFormatter = DateTimeFormat.forPattern("dd MMM yyyy")
             .withLocale(Locale.FRANCE).withZoneUTC();
-        
+
         DateTime date = dateFormatter.parseDateTime("23 janvier 2007");
         check(date, 2007, 1, 23);
     }
@@ -957,7 +971,7 @@ public class TestDateTimeFormat extends TestCase {
     public void testFormatParse_textMonthApr_France() {
         DateTimeFormatter dateFormatter = DateTimeFormat.forPattern("dd MMM yyyy")
             .withLocale(Locale.FRANCE).withZoneUTC();
-        
+
         String str = new DateTime(2007, 2, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("23 f\u00E9vr. 2007", str);  // e acute
         DateTime date = dateFormatter.parseDateTime(str);
@@ -967,7 +981,7 @@ public class TestDateTimeFormat extends TestCase {
     public void testFormatParse_textMonthAtEnd_France() {
         DateTimeFormatter dateFormatter = DateTimeFormat.forPattern("dd MMM")
             .withLocale(Locale.FRANCE).withZoneUTC();
-        
+
         String str = new DateTime(2007, 6, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("23 juin", str);
         DateTime date = dateFormatter.parseDateTime(str);
@@ -977,7 +991,7 @@ public class TestDateTimeFormat extends TestCase {
     public void testFormatParse_textMonthAtEnd_France_withSpecifiedDefault() {
         DateTimeFormatter dateFormatter = DateTimeFormat.forPattern("dd MMM")
             .withLocale(Locale.FRANCE).withZoneUTC().withDefaultYear(1980);
-        
+
         String str = new DateTime(2007, 6, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("23 juin", str);
         DateTime date = dateFormatter.parseDateTime(str);
@@ -987,7 +1001,7 @@ public class TestDateTimeFormat extends TestCase {
     public void testFormatParse_textMonthApr_Korean() {
         DateTimeFormatter dateFormatter = DateTimeFormat.forPattern("EEEE, d MMMM yyyy HH:mm")
             .withLocale(Locale.KOREAN).withZoneUTC();
-        
+
         String str = new DateTime(2007, 3, 8, 22, 0, 0, 0, UTC).toString(dateFormatter);
         DateTime date = dateFormatter.parseDateTime(str);
         assertEquals(new DateTime(2007, 3, 8, 22, 0, 0, 0, UTC), date);
@@ -1004,7 +1018,7 @@ public class TestDateTimeFormat extends TestCase {
             .appendYear(4, 4)
             .toFormatter()
             .withLocale(Locale.UK).withZoneUTC();
-        
+
         String str = new DateTime(2007, 6, 23, 18, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("$06-PM-2007", str);
         DateTime date = dateFormatter.parseDateTime(str);
@@ -1021,7 +1035,7 @@ public class TestDateTimeFormat extends TestCase {
             .appendYear(4, 4)
             .toFormatter()
             .withLocale(Locale.FRANCE).withZoneUTC();
-        
+
         String str = new DateTime(2007, 6, 23, 18, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("$06-PM-2007", str);
         DateTime date = dateFormatter.parseDateTime(str);
@@ -1036,7 +1050,7 @@ public class TestDateTimeFormat extends TestCase {
             .appendYear(4, 4)
             .toFormatter()
             .withLocale(Locale.UK).withZoneUTC();
-        
+
         String str = new DateTime(2007, 6, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("$AD2007", str);
         DateTime date = dateFormatter.parseDateTime(str);
@@ -1050,7 +1064,7 @@ public class TestDateTimeFormat extends TestCase {
             .appendYear(4, 4)
             .toFormatter()
             .withLocale(Locale.FRANCE).withZoneUTC();
-        
+
         String str = new DateTime(2007, 6, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("$ap. J.-C.2007", str);
         DateTime date = dateFormatter.parseDateTime(str);
@@ -1064,7 +1078,7 @@ public class TestDateTimeFormat extends TestCase {
             .appendYear(4, 4)
             .toFormatter()
             .withLocale(Locale.FRANCE).withZoneUTC();
-        
+
         String str = new DateTime(-1, 6, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("$BC-0001", str);
         DateTime date = dateFormatter.parseDateTime(str);
@@ -1078,7 +1092,7 @@ public class TestDateTimeFormat extends TestCase {
             .appendText(DateTimeFieldType.year())
             .toFormatter()
             .withLocale(Locale.UK).withZoneUTC();
-        
+
         String str = new DateTime(2007, 6, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("$2007", str);
         try {
@@ -1095,7 +1109,7 @@ public class TestDateTimeFormat extends TestCase {
             .appendText(DateTimeFieldType.year())
             .toFormatter()
             .withLocale(Locale.FRANCE).withZoneUTC();
-        
+
         String str = new DateTime(2007, 6, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("$2007", str);
         try {
@@ -1115,7 +1129,7 @@ public class TestDateTimeFormat extends TestCase {
             .appendLiteral("HelloWorld")
             .toFormatter()
             .withLocale(Locale.UK).withZoneUTC();
-        
+
         String str = new DateTime(2007, 6, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("$23JunHelloWorld", str);
         dateFormatter.parseDateTime(str);
@@ -1129,7 +1143,7 @@ public class TestDateTimeFormat extends TestCase {
             .appendDayOfWeekShortText()
             .toFormatter()
             .withLocale(Locale.UK).withZoneUTC();
-        
+
         String str = new DateTime(2007, 6, 23, 0, 0, 0, 0, UTC).toString(dateFormatter);
         assertEquals("$23JunSat", str);
         dateFormatter.parseDateTime(str);


### PR DESCRIPTION
- New PR without the whitespace changes
- Adds support for quarters of a year
- Add support for using "Q" as a placeholders for a quarter in parsed time formats
- Adds basic tests for quarter syntax and field validity