### PR TITLE
Load timezone resources in doPrivileged block

### DIFF
--- a/src/main/java/org/joda/time/tz/ZoneInfoProvider.java
+++ b/src/main/java/org/joda/time/tz/ZoneInfoProvider.java
@@ -21,6 +21,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.SoftReference;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -195,9 +197,13 @@ public class ZoneInfoProvider implements Provider {
         if (iFileDir != null) {
             in = new FileInputStream(new File(iFileDir, name));
         } else {
-            String path = iResourcePath.concat(name);
+            final String path = iResourcePath.concat(name);
             if (iLoader != null) {
-                in = iLoader.getResourceAsStream(path);
+                in = AccessController.doPrivileged(new PrivilegedAction<InputStream>() {
+                    public InputStream run() {
+                        return iLoader.getResourceAsStream(path);
+                    }
+                });
             } else {
                 in = ClassLoader.getSystemResourceAsStream(path);
             }


### PR DESCRIPTION
Under a security manager, loading resources requries
java.io.FilePermission. This commit modifies the loading of such
resources so they are done in an appropriate doPrivileged block.

Closes #327