### PR TITLE
fixes #284 - Generate source and Javadoc artifacts for no-tzdb artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,28 +433,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-no-tzdb-javadoc</id>
-            <phase>package</phase>
-            <goals>
-              <goal>attach-artifact</goal>
-            </goals>
-            <configuration>
-              <artifacts>
-                <artifact>
-                  <file>${project.build.directory}/${project.artifactId}-${project.version}-javadoc.jar</file>
-                  <type>jar</type>
-                  <classifier>no-tzdb-javadoc</classifier>
-                </artifact>
-              </artifacts>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <executions>
@@ -851,6 +829,41 @@
       <properties>
         <additionalparam></additionalparam>
       </properties>
+    </profile>
+    <profile>
+      <id>attach-additional-javadoc</id>
+      <activation>
+        <property>
+          <name>maven.javadoc.skip</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-no-tzdb-javadoc</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>attach-artifact</goal>
+                </goals>
+                <configuration>
+                  <artifacts>
+                    <artifact>
+                      <file>${project.build.directory}/${project.artifactId}-${project.version}-javadoc.jar</file>
+                      <type>jar</type>
+                      <classifier>no-tzdb-javadoc</classifier>
+                    </artifact>
+                  </artifacts>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>joda-time</artifactId>
   <packaging>jar</packaging>
   <name>Joda-Time</name>
-  <version>2.9.4</version>
+  <version>2.9.5-SNAPSHOT</version>
   <description>Date and time library to replace JDK date handling</description>
   <url>http://www.joda.org/joda-time/</url>
 
@@ -433,6 +433,28 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-no-tzdb-javadoc</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${project.build.directory}/${project.artifactId}-${project.version}-javadoc.jar</file>
+                  <type>jar</type>
+                  <classifier>no-tzdb-javadoc</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <executions>
@@ -443,7 +465,20 @@
               <goal>jar-no-fork</goal>
             </goals>
           </execution>
-        </executions>
+          <execution>
+            <id>attach-no-tztb-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+            <configuration>
+              <classifier>no-tzdb-sources</classifier>
+              <excludes>
+                <exclude>org/joda/time/tz/data/**</exclude>
+                <exclude>org/joda/time/tz/ZoneInfoCompiler*</exclude>
+              </excludes>
+            </configuration>
+          </execution>        </executions>
         <!-- work around maven bug where properties files added twice -->
         <configuration>
           <excludes>
@@ -638,6 +673,11 @@
           <artifactId>maven-toolchains-plugin</artifactId>
           <version>${maven-toolchains-plugin.version}</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build-helper-maven-plugin.version}</version>
+        </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
@@ -817,6 +857,7 @@
   <!-- ==================================================================== -->
   <properties>
     <!-- Plugin version numbers -->
+    <build-helper-maven-plugin.version>1.12</build-helper-maven-plugin.version>
     <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
     <maven-changes-plugin.version>2.11</maven-changes-plugin.version>
     <maven-checkstyle-plugin.version>2.16</maven-checkstyle-plugin.version>


### PR DESCRIPTION
Fixes #284 by generating an additional sources JAR and adding the existing Javadoc JAR again.  I couldn't see how to generate Javadoc again with different exclusions without a lot of duplicated config, but that is probably not necessary for most tooling, and doesn't seem to be needed by Android Studio to fix the attached defect.

Probably an FYI rather than a fix that is worth implementing, though you could always upload the additional JARs to Maven central even if a new version is not required.
