### PR TITLE
Update TimeZone Database to 2016g

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -19,10 +19,10 @@ Changes in 2.9.5
 
  - Add Duration.dividedBy(long,RoundingMode) [#69, #379]
 
- - DateTimeZone data updated to version 2016f
- 
+ - DateTimeZone data updated to version 2016g
+
  - Fixed minor issues with historic time-zone data [#373]
- 
+
  - Fix bug in time-zone binary search [#332, #386]
   The fix in v2.9.2 caused problems when the time-zone being parsed
   was not the last element in the input string. New approach uses a
@@ -54,7 +54,7 @@ Changes in 2.9.2
  - Fix bug in time-zone binary search [#332]
 
  - Minor fixes to code internals [#339, #326, #344, #350, #343]
- 
+
  - Better document behaviour [#325]
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
     <!-- define build -->
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>      
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <executions>
@@ -914,6 +914,6 @@
     <!-- Other properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <tz.database.version>2016f</tz.database.version>
+    <tz.database.version>2016g</tz.database.version>
   </properties>
 </project>

--- a/src/main/java/org/joda/time/tz/src/africa
+++ b/src/main/java/org/joda/time/tz/src/africa
@@ -464,7 +464,7 @@ Zone	Africa/Monrovia	-0:43:08 -	LMT	1882
 # http://www.libyaherald.com/2013/10/24/correction-no-time-change-tomorrow/
 #
 # From Paul Eggert (2013-10-25):
-# For now, assume they're reverting to the pre-2012 rules of permanent UTC+2.
+# For now, assume they're reverting to the pre-2012 rules of permanent UT +02.
 
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
 Rule	Libya	1951	only	-	Oct	14	2:00	1:00	S

--- a/src/main/java/org/joda/time/tz/src/antarctica
+++ b/src/main/java/org/joda/time/tz/src/antarctica
@@ -10,9 +10,7 @@
 # http://www.spri.cam.ac.uk/bob/periant.htm
 # for information.
 # Unless otherwise specified, we have no time zone information.
-#
-# Except for the French entries,
-# I made up all time zone abbreviations mentioned here; corrections welcome!
+
 # FORMAT is '-00' and GMTOFF is 0 for locations while uninhabited.
 
 # Argentina - year-round bases
@@ -29,7 +27,7 @@
 #	previously sealers and scientific personnel wintered
 #	Margaret Turner reports
 #	http://web.archive.org/web/20021204222245/http://www.dstc.qut.edu.au/DST/marg/daylight.html
-#	(1999-09-30) that they're UTC+5, with no DST;
+#	(1999-09-30) that they're UT +05, with no DST;
 #	presumably this is when they have visitors.
 #
 # year-round bases
@@ -68,23 +66,22 @@
 
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Casey	0	-	-00	1969
-			8:00	-	AWST	2009 Oct 18  2:00
-						# Australian Western Std Time
-			11:00	-	CAST	2010 Mar  5  2:00  # Casey Time
-			8:00	-	AWST	2011 Oct 28  2:00
-			11:00	-	CAST	2012 Feb 21 17:00u
-			8:00	-	AWST
+			8:00	-	+08	2009 Oct 18  2:00
+			11:00	-	+11	2010 Mar  5  2:00
+			8:00	-	+08	2011 Oct 28  2:00
+			11:00	-	+11	2012 Feb 21 17:00u
+			8:00	-	+08
 Zone Antarctica/Davis	0	-	-00	1957 Jan 13
-			7:00	-	DAVT	1964 Nov    # Davis Time
+			7:00	-	+07	1964 Nov
 			0	-	-00	1969 Feb
-			7:00	-	DAVT	2009 Oct 18  2:00
-			5:00	-	DAVT	2010 Mar 10 20:00u
-			7:00	-	DAVT	2011 Oct 28  2:00
-			5:00	-	DAVT	2012 Feb 21 20:00u
-			7:00	-	DAVT
+			7:00	-	+07	2009 Oct 18  2:00
+			5:00	-	+05	2010 Mar 10 20:00u
+			7:00	-	+07	2011 Oct 28  2:00
+			5:00	-	+05	2012 Feb 21 20:00u
+			7:00	-	+07
 Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
-			6:00	-	MAWT	2009 Oct 18  2:00 # Mawson Time
-			5:00	-	MAWT
+			6:00	-	+06	2009 Oct 18  2:00
+			5:00	-	+05
 # References:
 # Casey Weather (1998-02-26)
 # http://www.antdiv.gov.au/aad/exop/sfo/casey/casey_aws.html
@@ -138,7 +135,7 @@ Zone Antarctica/Mawson	0	-	-00	1954 Feb 13
 #
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone Indian/Kerguelen	0	-	-00	1950 # Port-aux-Français
-			5:00	-	TFT	# ISO code TF Time
+			5:00	-	+05
 #
 # year-round base in the main continent
 # Dumont d'Urville, Île des Pétrels, -6640+14001, since 1956-11
@@ -149,9 +146,9 @@ Zone Indian/Kerguelen	0	-	-00	1950 # Port-aux-Français
 #
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/DumontDUrville 0 -	-00	1947
-			10:00	-	PMT	1952 Jan 14 # Port-Martin Time
+			10:00	-	+10	1952 Jan 14
 			0	-	-00	1956 Nov
-			10:00	-	DDUT	# Dumont-d'Urville Time
+			10:00	-	+10
 
 # France & Italy - year-round base
 # Concordia, -750600+1232000, since 2005
@@ -177,7 +174,7 @@ Zone Antarctica/DumontDUrville 0 -	-00	1947
 # station of Japan, it's appropriate for the principal location.
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Syowa	0	-	-00	1957 Jan 29
-			3:00	-	SYOT	# Syowa Time
+			3:00	-	+03
 # See:
 # NIPR Antarctic Research Activities (1999-08-17)
 # http://www.nipr.ac.jp/english/ara01.html
@@ -214,17 +211,17 @@ Zone Antarctica/Syowa	0	-	-00	1957 Jan 29
 # correct, but they should be quite close to the actual dates.
 #
 # From Paul Eggert (2014-03-21):
-# The CET-switching Troll rules require zic from tzcode 2014b or later, so as
+# The CET-switching Troll rules require zic from tz 2014b or later, so as
 # suggested by Bengt-Inge Larsson comment them out for now, and approximate
 # with only UTC and CEST.  Uncomment them when 2014b is more prevalent.
 #
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
-#Rule	Troll	2005	max	-	Mar	 1	1:00u	1:00	CET
-Rule	Troll	2005	max	-	Mar	lastSun	1:00u	2:00	CEST
-#Rule	Troll	2005	max	-	Oct	lastSun	1:00u	1:00	CET
-#Rule	Troll	2004	max	-	Nov	 7	1:00u	0:00	UTC
+#Rule	Troll	2005	max	-	Mar	 1	1:00u	1:00	+01
+Rule	Troll	2005	max	-	Mar	lastSun	1:00u	2:00	+02
+#Rule	Troll	2005	max	-	Oct	lastSun	1:00u	1:00	+01
+#Rule	Troll	2004	max	-	Nov	 7	1:00u	0:00	+00
 # Remove the following line when uncommenting the above '#Rule' lines.
-Rule	Troll	2004	max	-	Oct	lastSun	1:00u	0:00	UTC
+Rule	Troll	2004	max	-	Oct	lastSun	1:00u	0:00	+00
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Troll	0	-	-00	2005 Feb 12
 			0:00	Troll	%s
@@ -265,10 +262,10 @@ Zone Antarctica/Troll	0	-	-00	2005 Feb 12
 # changes during the year and does not necessarily correspond to mean
 # solar noon.  So the Vostok time might have been whatever the clocks
 # happened to be during their visit.  So we still don't really know what time
-# it is at Vostok.  But we'll guess UTC+6.
+# it is at Vostok.  But we'll guess +06.
 #
 Zone Antarctica/Vostok	0	-	-00	1957 Dec 16
-			6:00	-	VOST	# Vostok time
+			6:00	-	+06
 
 # S Africa - year-round bases
 # Marion Island, -4653+03752
@@ -301,7 +298,7 @@ Zone Antarctica/Vostok	0	-	-00	1957 Dec 16
 #
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone Antarctica/Rothera	0	-	-00	1976 Dec  1
-			-3:00	-	ROTT	# Rothera time
+			-3:00	-	-03
 
 # Uruguay - year round base
 # Artigas, King George Island, -621104-0585107

--- a/src/main/java/org/joda/time/tz/src/asia
+++ b/src/main/java/org/joda/time/tz/src/asia
@@ -116,13 +116,11 @@ Zone	Asia/Kabul	4:36:48 -	LMT	1890
 # http://www.worldtimezone.com/dst_news/dst_news_armenia03.html
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Yerevan	2:58:00 -	LMT	1924 May  2
-			3:00	-	YERT	1957 Mar    # Yerevan Time
-			4:00 RussiaAsia YER%sT	1991 Mar 31  2:00s
-			3:00	1:00	YERST	1991 Sep 23 # independence
-			3:00 RussiaAsia	AM%sT	1995 Sep 24  2:00s
-			4:00	-	AMT	1997
-			4:00 RussiaAsia	AM%sT	2012 Feb  9
-			4:00	-	AMT
+			3:00	-	+03	1957 Mar
+			4:00 RussiaAsia +04/+05	1991 Mar 31  2:00s
+			3:00 RussiaAsia	+03/+04	1995 Sep 24  2:00s
+			4:00	-	+04	1997
+			4:00 RussiaAsia	+04/+05
 
 # Azerbaijan
 
@@ -143,13 +141,12 @@ Rule	Azer	1997	2015	-	Mar	lastSun	 4:00	1:00	S
 Rule	Azer	1997	2015	-	Oct	lastSun	 5:00	0	-
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Baku	3:19:24 -	LMT	1924 May  2
-			3:00	-	BAKT	1957 Mar    # Baku Time
-			4:00 RussiaAsia BAK%sT	1991 Mar 31  2:00s
-			3:00	1:00	BAKST	1991 Aug 30 # independence
-			3:00 RussiaAsia	AZ%sT	1992 Sep lastSun  2:00s
-			4:00	-	AZT	1996     # Azerbaijan Time
-			4:00	EUAsia	AZ%sT	1997
-			4:00	Azer	AZ%sT
+			3:00	-	+03	1957 Mar
+			4:00 RussiaAsia +04/+05	1991 Mar 31  2:00s
+			3:00 RussiaAsia	+03/+04	1992 Sep lastSun  2:00s
+			4:00	-	+04	1996
+			4:00	EUAsia	+04/+05	1997
+			4:00	Azer	+04/+05
 
 # Bahrain
 # See Asia/Qatar.
@@ -268,7 +265,7 @@ Zone	Asia/Brunei	7:39:40 -	LMT	1926 Mar # Bandar Seri Begawan
 # Milne says 6:24:40 was the meridian of the time ball observatory at Rangoon.
 
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
-Zone	Asia/Rangoon	6:24:40 -	LMT	1880        # or Yangon
+Zone	Asia/Yangon	6:24:40 -	LMT	1880        # or Rangoon
 			6:24:40	-	RMT	1920        # Rangoon Mean Time?
 			6:30	-	BURT	1942 May    # Burma Time
 			9:00	-	JST	1945 May  3
@@ -383,7 +380,7 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 # Lewiston (ME) Daily Sun (1939-05-29), p 17, said "Even the time is
 # different - the occupied districts going by Tokyo time, an hour
 # ahead of that prevailing in the rest of Shanghai."  Guess that the
-# Xujiahui Observatory was under French control and stuck with UT+8.
+# Xujiahui Observatory was under French control and stuck with UT +08.
 #
 # In earlier versions of this file, China had many separate Zone entries, but
 # this was based on what were apparently incorrect data in Shanks & Pottenger.
@@ -392,26 +389,26 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 # Proposed in 1918 and theoretically in effect until 1949 (although in practice
 # mainly observed in coastal areas), the five zones were:
 #
-# Changbai Time ("Long-white Time", Long-white = Heilongjiang area) UT+8.5
+# Changbai Time ("Long-white Time", Long-white = Heilongjiang area) UT +08:30
 # Asia/Harbin (currently a link to Asia/Shanghai)
 # Heilongjiang (except Mohe county), Jilin
 #
-# Zhongyuan Time ("Central plain Time") UT+8
+# Zhongyuan Time ("Central plain Time") UT +08
 # Asia/Shanghai
 # most of China
 # This currently represents most other zones as well,
 # as apparently these regions have been the same since 1970.
 # Milne gives 8:05:43.2 for Xujiahui Observatory time; round to nearest.
-# Guo says Shanghai switched to UT+8 "from the end of the 19th century".
+# Guo says Shanghai switched to UT +08 "from the end of the 19th century".
 #
-# Long-shu Time (probably due to Long and Shu being two names of that area) UT+7
+# Long-shu Time (probably due to Long and Shu being two names of the area) UT +07
 # Asia/Chongqing (currently a link to Asia/Shanghai)
 # Guangxi, Guizhou, Hainan, Ningxia, Sichuan, Shaanxi, and Yunnan;
 # most of Gansu; west Inner Mongolia; west Qinghai; and the Guangdong
 # counties Deqing, Enping, Kaiping, Luoding, Taishan, Xinxing,
 # Yangchun, Yangjiang, Yu'nan, and Yunfu.
 #
-# Xin-zang Time ("Xinjiang-Tibet Time") UT+6
+# Xin-zang Time ("Xinjiang-Tibet Time") UT +06
 # Asia/Urumqi
 # This currently represents Kunlun Time as well,
 # as apparently the two regions have been the same since 1970.
@@ -424,7 +421,7 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 # Shihezi, Changji, Yanqi, Heshuo, Tuokexun, Tulufan, Shanshan, Hami,
 # Fukang, Kuitun, Kumukuli, Miquan, Qitai, and Turfan.
 #
-# Kunlun Time UT+5.5
+# Kunlun Time UT +05:30
 # Asia/Kashgar (currently a link to Asia/Urumqi)
 # West Tibet, including Pulan, Aheqi, Shufu, Shule;
 # West Xinjiang, including Aksu, Atushi, Yining, Hetian, Cele, Luopu, Nileke,
@@ -440,7 +437,7 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 #
 # On the other hand, ethnic Uyghurs, who make up about half the
 # population of Xinjiang, typically use "Xinjiang time" which is two
-# hours behind Beijing time, or UTC +0600. The government of the Xinjiang
+# hours behind Beijing time, or UT +06. The government of the Xinjiang
 # Uyghur Autonomous Region, (XAUR, or just Xinjiang for short) as well as
 # local governments such as the Ürümqi city government use both times in
 # publications, referring to what is popularly called Xinjiang time as
@@ -496,8 +493,8 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 # having the same time as Beijing.
 
 # From Paul Eggert (2014-06-30):
-# In the early days of the PRC, Tibet was given its own time zone (UT+6) but
-# this was withdrawn in 1959 and never reinstated; see Tubten Khétsun,
+# In the early days of the PRC, Tibet was given its own time zone (UT +06)
+# but this was withdrawn in 1959 and never reinstated; see Tubten Khétsun,
 # Memories of life in Lhasa under Chinese Rule, Columbia U Press, ISBN
 # 978-0231142861 (2008), translator's introduction by Matthew Akester, p x.
 # As this is before our 1970 cutoff, Tibet doesn't need a separate zone.
@@ -511,12 +508,12 @@ Rule	PRC	1987	1991	-	Apr	Sun>=10	0:00	1:00	D
 # Republics, the Soviet Union, the Kuomintang, and the People's Republic of
 # China, and tracking down all these organizations' timekeeping rules would be
 # quite a trick.  Approximate this lost history by a transition from LMT to
-# XJT at the start of 1928, the year of accession of the warlord Jin Shuren,
+# UT +06 at the start of 1928, the year of accession of the warlord Jin Shuren,
 # which happens to be the date given by Shanks & Pottenger (no doubt as a
-# guess) as the transition from LMT.  Ignore the usage of UT+8 before
-# 1986-02-01 under the theory that the transition date to UT+8 is unknown and
+# guess) as the transition from LMT.  Ignore the usage of +08 before
+# 1986-02-01 under the theory that the transition date to +08 is unknown and
 # that the sort of users who prefer Asia/Urumqi now typically ignored the
-# UT+8 mandate back then.
+# +08 mandate back then.
 
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 # Beijing time, used throughout China; represented by Shanghai.
@@ -721,7 +718,7 @@ Zone	Asia/Hong_Kong	7:36:42 -	LMT	1904 Oct 30
 # be found from historical government announcement database.
 
 # From Paul Eggert (2014-07-03):
-# As per Yu-Cheng Chuang, say that Taiwan was at UT+9 from 1937-10-01
+# As per Yu-Cheng Chuang, say that Taiwan was at UT +09 from 1937-10-01
 # until 1945-09-21 at 01:00, overriding Shanks & Pottenger.
 # Likewise, use Yu-Cheng Chuang's data for DST in Taiwan.
 
@@ -835,16 +832,15 @@ Link	Asia/Nicosia	Europe/Nicosia
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Tbilisi	2:59:11 -	LMT	1880
 			2:59:11	-	TBMT	1924 May  2 # Tbilisi Mean Time
-			3:00	-	TBIT	1957 Mar    # Tbilisi Time
-			4:00 RussiaAsia TBI%sT	1991 Mar 31  2:00s
-			3:00	1:00	TBIST	1991 Apr  9 # independence
-			3:00 RussiaAsia GE%sT	1992        # Georgia Time
-			3:00 E-EurAsia	GE%sT	1994 Sep lastSun
-			4:00 E-EurAsia	GE%sT	1996 Oct lastSun
-			4:00	1:00	GEST	1997 Mar lastSun
-			4:00 E-EurAsia	GE%sT	2004 Jun 27
-			3:00 RussiaAsia	GE%sT	2005 Mar lastSun  2:00
-			4:00	-	GET
+			3:00	-	+03	1957 Mar
+			4:00 RussiaAsia +04/+05	1991 Mar 31  2:00s
+			3:00 RussiaAsia +03/+04	1992
+			3:00 E-EurAsia	+03/+04	1994 Sep lastSun
+			4:00 E-EurAsia	+04/+05	1996 Oct lastSun
+			4:00	1:00	+05	1997 Mar lastSun
+			4:00 E-EurAsia	+04/+05	2004 Jun 27
+			3:00 RussiaAsia	+03/+04	2005 Mar lastSun  2:00
+			4:00	-	+04
 
 # East Timor
 
@@ -921,7 +917,7 @@ Zone	Asia/Kolkata	5:53:28 -	LMT	1880        # Kolkata
 # These would be the earliest possible times for a change.
 # Régimes horaires pour le monde entier, by Henri Le Corre, (Éditions
 # Traditionnelles, 1987, Paris) says that Java and Madura switched
-# from JST to UTC+07:30 on 1945-09-23, and gives 1944-09-01 for Jayapura
+# from UT +09 to +07:30 on 1945-09-23, and gives 1944-09-01 for Jayapura
 # (Hollandia).  For now, assume all Indonesian locations other than Jayapura
 # switched on 1945-09-23.
 #
@@ -932,11 +928,11 @@ Zone	Asia/Kolkata	5:53:28 -	LMT	1880        # Kolkata
 # summary published by the Time and Frequency Laboratory of the
 # Research Center for Calibration, Instrumentation and Metrology,
 # Indonesia, <http://time.kim.lipi.go.id/time-eng.php> (2006-09-29).
-# The abbreviations are:
+# The time zone abbreviations and UT offsets are:
 #
-# WIB  - UTC+7 - Waktu Indonesia Barat (Indonesia western time)
-# WITA - UTC+8 - Waktu Indonesia Tengah (Indonesia central time)
-# WIT  - UTC+9 - Waktu Indonesia Timur (Indonesia eastern time)
+# WIB  - +07 - Waktu Indonesia Barat (Indonesia western time)
+# WITA - +08 - Waktu Indonesia Tengah (Indonesia central time)
+# WIT  - +09 - Waktu Indonesia Timur (Indonesia eastern time)
 #
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 # Java, Sumatra
@@ -1825,11 +1821,11 @@ Rule	Kyrgyz	1997	2005	-	Mar	lastSun	2:30	1:00	S
 Rule	Kyrgyz	1997	2004	-	Oct	lastSun	2:30	0	-
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Bishkek	4:58:24 -	LMT	1924 May  2
-			5:00	-	FRUT	1930 Jun 21 # Frunze Time
-			6:00 RussiaAsia FRU%sT	1991 Mar 31  2:00s
-			5:00	1:00	FRUST	1991 Aug 31  2:00 # independence
-			5:00	Kyrgyz	KG%sT	2005 Aug 12 # Kyrgyzstan Time
-			6:00	-	KGT
+			5:00	-	+05	1930 Jun 21
+			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
+			5:00 RussiaAsia	+05/+06	1991 Aug 31  2:00
+			5:00	Kyrgyz	+05/+06	2005 Aug 12
+			6:00	-	+06
 
 ###############################################################################
 
@@ -1868,25 +1864,24 @@ Rule	ROK	1957	1960	-	Sep	Sun>=18	0:00	0	S
 Rule	ROK	1987	1988	-	May	Sun>=8	2:00	1:00	D
 Rule	ROK	1987	1988	-	Oct	Sun>=8	3:00	0	S
 
-# From Paul Eggert (2014-10-30):
+# From Paul Eggert (2016-08-23):
 # The Korean Wikipedia entry gives the following sources for UT offsets:
 #
-# 1908: Official Journal Article No. 3994 (Edict No. 5)
+# 1908: Official Journal Article No. 3994 (decree No. 5)
 # 1912: Governor-General of Korea Official Gazette Issue No. 367
 #       (Announcement No. 338)
 # 1954: Presidential Decree No. 876 (1954-03-17)
 # 1961: Law No. 676 (1961-08-07)
-# 1987: Law No. 3919 (1986-12-31)
 #
-# The Wikipedia entry also has confusing information about a change
-# to UT+9 in April 1910, but then what would be the point of the later change
-# to UT+9 on 1912-01-01?  Omit the 1910 change for now.
+# (Another source "1987: Law No. 3919 (1986-12-31)" was in the 2014-10-30
+# edition of the Korean Wikipedia entry.)
 #
 # I guessed that time zone abbreviations through 1945 followed the same
 # rules as discussed under Taiwan, with nominal switches from JST to KST
 # when the respective cities were taken over by the Allies after WWII.
 #
-# For Pyongyang we have no information; guess no changes since World War II.
+# For Pyongyang, guess no changes from World War II until 2015, as we
+# have no information otherwise.
 
 # From Steffen Thorsen (2015-08-07):
 # According to many news sources, North Korea is going to change to
@@ -2046,7 +2041,7 @@ Zone	Indian/Maldives	4:54:00 -	LMT	1880 # Male
 # Bill Bonnet (2005-05-19) reports that the US Embassy in Ulaanbaatar says
 # there is only one time zone and that DST is observed, citing Microsoft
 # Windows XP as the source.  Risto Nykänen (2005-05-16) reports that
-# travelmongolia.org says there are two time zones (UTC+7, UTC+8) with no DST.
+# travelmongolia.org says there are two time zones (UT +07, +08) with no DST.
 # Oscar van Vlijmen (2005-05-20) reports that the Mongolian Embassy in
 # Washington, DC says there are two time zones, with DST observed.
 # He also found
@@ -2682,7 +2677,7 @@ Link Asia/Qatar Asia/Bahrain
 # earlier date.
 #
 # Shanks & Pottenger also state that until 1968-05-01 Saudi Arabia had two
-# time zones; the other zone, at UTC+4, was in the far eastern part of
+# time zones; the other zone, at UT +04, was in the far eastern part of
 # the country.  Ignore this, as it's before our 1970 cutoff.
 #
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
@@ -2951,10 +2946,10 @@ Zone	Asia/Damascus	2:25:12 -	LMT	1920 # Dimashq
 # From Shanks & Pottenger.
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Dushanbe	4:35:12 -	LMT	1924 May  2
-			5:00	-	DUST	1930 Jun 21 # Dushanbe Time
-			6:00 RussiaAsia DUS%sT	1991 Mar 31  2:00s
-			5:00	1:00	DUSST	1991 Sep  9  2:00s
-			5:00	-	TJT	# Tajikistan Time
+			5:00	-	+05	1930 Jun 21
+			6:00 RussiaAsia +06/+07	1991 Mar 31  2:00s
+			5:00	1:00	+05/+06	1991 Sep  9  2:00s
+			5:00	-	+05
 
 # Thailand
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
@@ -2968,11 +2963,10 @@ Link Asia/Bangkok Asia/Vientiane	# Laos
 # From Shanks & Pottenger.
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Ashgabat	3:53:32 -	LMT	1924 May  2 # or Ashkhabad
-			4:00	-	ASHT	1930 Jun 21 # Ashkhabad Time
-			5:00 RussiaAsia	ASH%sT	1991 Mar 31  2:00
-			4:00 RussiaAsia	ASH%sT	1991 Oct 27 # independence
-			4:00 RussiaAsia	TM%sT	1992 Jan 19  2:00
-			5:00	-	TMT
+			4:00	-	+04	1930 Jun 21
+			5:00 RussiaAsia	+05/+06	1991 Mar 31  2:00
+			4:00 RussiaAsia	+04/+05	1992 Jan 19  2:00
+			5:00	-	+05
 
 # United Arab Emirates
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
@@ -2984,20 +2978,18 @@ Link Asia/Dubai Asia/Muscat	# Oman
 # Byalokoz 1919 says Uzbekistan was 4:27:53.
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Asia/Samarkand	4:27:53 -	LMT	1924 May  2
-			4:00	-	SAMT	1930 Jun 21 # Samarkand Time
-			5:00	-	SAMT	1981 Apr  1
-			5:00	1:00	SAMST	1981 Oct  1
-			6:00	-	TAST	1982 Apr  1 # Tashkent Time
-			5:00 RussiaAsia	SAM%sT	1991 Sep  1 # independence
-			5:00 RussiaAsia	UZ%sT	1992
-			5:00	-	UZT
+			4:00	-	+04	1930 Jun 21
+			5:00	-	+05	1981 Apr  1
+			5:00	1:00	+06	1981 Oct  1
+			6:00	-	+06	1982 Apr  1
+			5:00 RussiaAsia	+05/+06	1992
+			5:00	-	+05
 # Milne says Tashkent was 4:37:10.8; round to nearest.
 Zone	Asia/Tashkent	4:37:11 -	LMT	1924 May  2
-			5:00	-	TAST	1930 Jun 21 # Tashkent Time
-			6:00 RussiaAsia	TAS%sT	1991 Mar 31  2:00
-			5:00 RussiaAsia	TAS%sT	1991 Sep  1 # independence
-			5:00 RussiaAsia	UZ%sT	1992
-			5:00	-	UZT
+			5:00	-	+05	1930 Jun 21
+			6:00 RussiaAsia	+06/+07	1991 Mar 31  2:00
+			5:00 RussiaAsia	+05/+06	1992
+			5:00	-	+05
 
 # Vietnam
 

--- a/src/main/java/org/joda/time/tz/src/australasia
+++ b/src/main/java/org/joda/time/tz/src/australasia
@@ -545,7 +545,7 @@ Zone Pacific/Port_Moresby 9:48:40 -	LMT	1880
 # Base the Bougainville entry on the Arawa-Kieta region, which appears to have
 # the most people even though it was devastated in the Bougainville Civil War.
 #
-# Although Shanks gives 1942-03-15 / 1943-11-01 for JST, these dates
+# Although Shanks gives 1942-03-15 / 1943-11-01 for UT +09, these dates
 # are apparently rough guesswork from the starts of military campaigns.
 # The World War II entries below are instead based on Arawa-Kieta.
 # The Japanese occupied Kieta in July 1942,
@@ -553,8 +553,8 @@ Zone Pacific/Port_Moresby 9:48:40 -	LMT	1880
 # http://pwencycl.kgbudge.com/B/o/Bougainville.htm
 # and seem to have controlled it until their 1945-08-21 surrender.
 #
-# The Autonomous Region of Bougainville plans to switch from UTC+10 to UTC+11
-# on 2014-12-28 at 02:00.  They call UTC+11 "Bougainville Standard Time";
+# The Autonomous Region of Bougainville switched from UT +10 to +11
+# on 2014-12-28 at 02:00.  They call +11 "Bougainville Standard Time";
 # abbreviate this as BST.  See:
 # http://www.bougainville24.com/bougainville-issues/bougainville-gets-own-timezone/
 #
@@ -620,7 +620,7 @@ Link Pacific/Pago_Pago Pacific/Midway # in US minor outlying islands
 # From Paul Eggert (2014-06-27):
 # The International Date Line Act 2011
 # http://www.parliament.gov.ws/images/ACTS/International_Date_Line_Act__2011_-_Eng.pdf
-# changed Samoa from UTC-11 to UTC+13, effective "12 o'clock midnight, on
+# changed Samoa from UT -11 to +13, effective "12 o'clock midnight, on
 # Thursday 29th December 2011".  The International Date Line was adjusted
 # accordingly.
 
@@ -715,7 +715,7 @@ Zone Pacific/Funafuti	11:56:52 -	LMT	1901
 # 1886-1891; Baker was similar but exact dates are not known.
 # Inhabited by civilians 1935-1942; U.S. military bases 1943-1944;
 # uninhabited thereafter.
-# Howland observed Hawaii Standard Time (UT-10:30) in 1937;
+# Howland observed Hawaii Standard Time (UT -10:30) in 1937;
 # see page 206 of Elgen M. Long and Marie K. Long,
 # Amelia Earhart: the Mystery Solved, Simon & Schuster (2000).
 # So most likely Howland and Baker observed Hawaii Time from 1935
@@ -1473,7 +1473,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # Zealand time.  I understand that is the time they keep locally, anyhow."
 # For now, assume this practice goes back to the introduction of standard time
 # in New Zealand, as this would make Chatham Islands time almost exactly match
-# LMT back when New Zealand was at UTC+11:30; also, assume Chatham Islands did
+# LMT back when New Zealand was at UT +11:30; also, assume Chatham Islands did
 # not observe New Zealand's prewar DST.
 
 ###############################################################################
@@ -1529,7 +1529,7 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # For now, we assume the Ladrones switched at the same time as the Philippines;
 # see Asia/Manila.
 
-# US Public Law 106-564 (2000-12-23) made UTC+10 the official standard time,
+# US Public Law 106-564 (2000-12-23) made UT +10 the official standard time,
 # under the name "Chamorro Standard Time".  There is no official abbreviation,
 # but Congressman Robert A. Underwood, author of the bill that became law,
 # wrote in a press release (2000-12-27) that he will seek the use of "ChST".
@@ -1541,15 +1541,15 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # "I am certain, having lived there for the past decade, that 'Truk'
 # (now properly known as Chuuk) ... is in the time zone GMT+10."
 #
-# Shanks & Pottenger write that Truk switched from UTC+10 to UTC+11
+# Shanks & Pottenger write that Truk switched from UT +10 to +11
 # on 1978-10-01; ignore this for now.
 
 # From Paul Eggert (1999-10-29):
 # The Federated States of Micronesia Visitors Board writes in
 # The Federated States of Micronesia - Visitor Information (1999-01-26)
 # http://www.fsmgov.org/info/clocks.html
-# that Truk and Yap are UTC+10, and Ponape and Kosrae are UTC+11.
-# We don't know when Kosrae switched from UTC+12; assume January 1 for now.
+# that Truk and Yap are UT +10, and Ponape and Kosrae are +11.
+# We don't know when Kosrae switched from +12; assume January 1 for now.
 
 
 # Midway
@@ -1615,11 +1615,11 @@ Zone	Pacific/Wallis	12:15:20 -	LMT	1901
 # ordaining - by a masterpiece of diplomatic flattery - that
 # the Fourth of July should be celebrated twice in that year."
 
-# Although Shanks & Pottenger says they both switched to UTC-11:30
-# in 1911, and to UTC-11 in 1950. many earlier sources give UTC-11
+# Although Shanks & Pottenger says they both switched to UT -11:30
+# in 1911, and to -11 in 1950. many earlier sources give -11
 # for American Samoa, e.g., the US National Bureau of Standards
 # circular "Standard Time Throughout the World", 1932.
-# Assume American Samoa switched to UTC-11 in 1911, not 1950,
+# Assume American Samoa switched to -11 in 1911, not 1950,
 # and that after 1950 they agreed until (western) Samoa skipped a
 # day in 2011.  Assume also that the Samoas follow the US and New
 # Zealand's "ST"/"DT" style of daylight-saving abbreviations.

--- a/src/main/java/org/joda/time/tz/src/backward
+++ b/src/main/java/org/joda/time/tz/src/backward
@@ -36,6 +36,7 @@ Link	Asia/Shanghai		Asia/Harbin
 Link	Asia/Urumqi		Asia/Kashgar
 Link	Asia/Kathmandu		Asia/Katmandu
 Link	Asia/Macau		Asia/Macao
+Link	Asia/Yangon		Asia/Rangoon
 Link	Asia/Ho_Chi_Minh	Asia/Saigon
 Link	Asia/Jerusalem		Asia/Tel_Aviv
 Link	Asia/Thimphu		Asia/Thimbu

--- a/src/main/java/org/joda/time/tz/src/etcetera
+++ b/src/main/java/org/joda/time/tz/src/etcetera
@@ -8,6 +8,13 @@
 # need now for the entries that are not on UTC are for ships at sea
 # that cannot use POSIX TZ settings.
 
+# Starting with POSIX 1003.1-2001, the entries below are all
+# unnecessary as settings for the TZ environment variable.  E.g.,
+# instead of TZ='Etc/GMT+4' one can use the POSIX setting TZ='<-04>+4'.
+#
+# Do not use a POSIX TZ setting like TZ='GMT+4', which is four hours
+# behind GMT but uses the completely misleading abbreviation "GMT".
+
 Zone	Etc/GMT		0	-	GMT
 Zone	Etc/UTC		0	-	UTC
 Zone	Etc/UCT		0	-	UCT
@@ -26,23 +33,13 @@ Link	Etc/GMT				Etc/GMT-0
 Link	Etc/GMT				Etc/GMT+0
 Link	Etc/GMT				Etc/GMT0
 
-# We use POSIX-style signs in the Zone names and the output abbreviations,
+# Be consistent with POSIX TZ settings in the Zone names,
 # even though this is the opposite of what many people expect.
 # POSIX has positive signs west of Greenwich, but many people expect
 # positive signs east of Greenwich.  For example, TZ='Etc/GMT+4' uses
-# the abbreviation "GMT+4" and corresponds to 4 hours behind UT
+# the abbreviation "-04" and corresponds to 4 hours behind UT
 # (i.e. west of Greenwich) even though many people would expect it to
 # mean 4 hours ahead of UT (i.e. east of Greenwich).
-#
-# In the draft 5 of POSIX 1003.1-200x, the angle bracket notation allows for
-# TZ='<GMT-4>+4'; if you want time zone abbreviations conforming to
-# ISO 8601 you can use TZ='<-0400>+4'.  Thus the commonly-expected
-# offset is kept within the angle bracket (and is used for display)
-# while the POSIX sign is kept outside the angle bracket (and is used
-# for calculation).
-#
-# Do not use a TZ setting like TZ='GMT+4', which is four hours behind
-# GMT but uses the completely misleading abbreviation "GMT".
 
 # Earlier incarnations of this package were not POSIX-compliant,
 # and had lines such as
@@ -51,30 +48,31 @@ Link	Etc/GMT				Etc/GMT0
 # way does a
 #		zic -l GMT-12
 # so we moved the names into the Etc subdirectory.
+# Also, the time zone abbreviations are now compatible with %z.
 
-Zone	Etc/GMT-14	14	-	GMT-14	# 14 hours ahead of GMT
-Zone	Etc/GMT-13	13	-	GMT-13
-Zone	Etc/GMT-12	12	-	GMT-12
-Zone	Etc/GMT-11	11	-	GMT-11
-Zone	Etc/GMT-10	10	-	GMT-10
-Zone	Etc/GMT-9	9	-	GMT-9
-Zone	Etc/GMT-8	8	-	GMT-8
-Zone	Etc/GMT-7	7	-	GMT-7
-Zone	Etc/GMT-6	6	-	GMT-6
-Zone	Etc/GMT-5	5	-	GMT-5
-Zone	Etc/GMT-4	4	-	GMT-4
-Zone	Etc/GMT-3	3	-	GMT-3
-Zone	Etc/GMT-2	2	-	GMT-2
-Zone	Etc/GMT-1	1	-	GMT-1
-Zone	Etc/GMT+1	-1	-	GMT+1
-Zone	Etc/GMT+2	-2	-	GMT+2
-Zone	Etc/GMT+3	-3	-	GMT+3
-Zone	Etc/GMT+4	-4	-	GMT+4
-Zone	Etc/GMT+5	-5	-	GMT+5
-Zone	Etc/GMT+6	-6	-	GMT+6
-Zone	Etc/GMT+7	-7	-	GMT+7
-Zone	Etc/GMT+8	-8	-	GMT+8
-Zone	Etc/GMT+9	-9	-	GMT+9
-Zone	Etc/GMT+10	-10	-	GMT+10
-Zone	Etc/GMT+11	-11	-	GMT+11
-Zone	Etc/GMT+12	-12	-	GMT+12
+Zone	Etc/GMT-14	14	-	+14
+Zone	Etc/GMT-13	13	-	+13
+Zone	Etc/GMT-12	12	-	+12
+Zone	Etc/GMT-11	11	-	+11
+Zone	Etc/GMT-10	10	-	+10
+Zone	Etc/GMT-9	9	-	+09
+Zone	Etc/GMT-8	8	-	+08
+Zone	Etc/GMT-7	7	-	+07
+Zone	Etc/GMT-6	6	-	+06
+Zone	Etc/GMT-5	5	-	+05
+Zone	Etc/GMT-4	4	-	+04
+Zone	Etc/GMT-3	3	-	+03
+Zone	Etc/GMT-2	2	-	+02
+Zone	Etc/GMT-1	1	-	+01
+Zone	Etc/GMT+1	-1	-	-01
+Zone	Etc/GMT+2	-2	-	-02
+Zone	Etc/GMT+3	-3	-	-03
+Zone	Etc/GMT+4	-4	-	-04
+Zone	Etc/GMT+5	-5	-	-05
+Zone	Etc/GMT+6	-6	-	-06
+Zone	Etc/GMT+7	-7	-	-07
+Zone	Etc/GMT+8	-8	-	-08
+Zone	Etc/GMT+9	-9	-	-09
+Zone	Etc/GMT+10	-10	-	-10
+Zone	Etc/GMT+11	-11	-	-11
+Zone	Etc/GMT+12	-12	-	-12

--- a/src/main/java/org/joda/time/tz/src/europe
+++ b/src/main/java/org/joda/time/tz/src/europe
@@ -75,8 +75,7 @@
 #        1:00       CET CEST CEMT Central Europe
 #        1:00:14    SET           Swedish (1879-1899)*
 #        2:00       EET EEST      Eastern Europe
-#        3:00       FET           Further-eastern Europe (2011-2014)*
-#        3:00       MSK MSD  MSM* Minsk, Moscow
+#        3:00       MSK MSD       Moscow
 
 # From Peter Ilieve (1994-12-04),
 # The original six [EU members]: Belgium, France, (West) Germany, Italy,
@@ -583,16 +582,33 @@ Rule	E-Eur	1979	1995	-	Sep	lastSun	 0:00	0	-
 Rule	E-Eur	1981	max	-	Mar	lastSun	 0:00	1:00	S
 Rule	E-Eur	1996	max	-	Oct	lastSun	 0:00	0	-
 
+
+# Daylight saving time for Russia and the Soviet Union
+#
+# The 1917-1921 decree URLs are from Alexander Belopolsky (2016-08-23).
+
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
 Rule	Russia	1917	only	-	Jul	 1	23:00	1:00	MST  # Moscow Summer Time
+#
+# Decree No. 142 (1917-12-22) http://istmat.info/node/28137
 Rule	Russia	1917	only	-	Dec	28	 0:00	0	MMT  # Moscow Mean Time
+#
+# Decree No. 497 (1918-05-30) http://istmat.info/node/30001
 Rule	Russia	1918	only	-	May	31	22:00	2:00	MDST # Moscow Double Summer Time
 Rule	Russia	1918	only	-	Sep	16	 1:00	1:00	MST
+#
+# Decree No. 258 (1919-05-29) http://istmat.info/node/37949
 Rule	Russia	1919	only	-	May	31	23:00	2:00	MDST
-Rule	Russia	1919	only	-	Jul	 1	 2:00	1:00	MSD
+#
+Rule	Russia	1919	only	-	Jul	 1	 0:00u	1:00	MSD
 Rule	Russia	1919	only	-	Aug	16	 0:00	0	MSK
+#
+# Decree No. 63 (1921-02-03) http://istmat.info/node/45840
 Rule	Russia	1921	only	-	Feb	14	23:00	1:00	MSD
-Rule	Russia	1921	only	-	Mar	20	23:00	2:00	MSM  # Midsummer
+#
+# Decree No. 121 (1921-03-07) http://istmat.info/node/45949
+Rule	Russia	1921	only	-	Mar	20	23:00	2:00	+05
+#
 Rule	Russia	1921	only	-	Sep	 1	 0:00	1:00	MSD
 Rule	Russia	1921	only	-	Oct	 1	 0:00	0	-
 # Act No. 925 of the Council of Ministers of the USSR (1980-10-24):
@@ -775,8 +791,6 @@ Zone	Europe/Vienna	1:05:21 -	LMT	1893 Apr
 # From Alexander Bokovoy (2014-10-09):
 # Belarussian government decided against changing to winter time....
 # http://eng.belta.by/all_news/society/Belarus-decides-against-adjusting-time-in-Russias-wake_i_76335.html
-# From Paul Eggert (2014-10-08):
-# Hence Belarus can share time zone abbreviations with Moscow again.
 #
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
 Zone	Europe/Minsk	1:50:16 -	LMT	1880
@@ -787,8 +801,7 @@ Zone	Europe/Minsk	1:50:16 -	LMT	1880
 			3:00	Russia	MSK/MSD	1990
 			3:00	-	MSK	1991 Mar 31  2:00s
 			2:00	Russia	EE%sT	2011 Mar 27  2:00s
-			3:00	-	FET	2014 Oct 26  1:00s
-			3:00	-	MSK
+			3:00	-	+03
 
 # Belgium
 #
@@ -1296,7 +1309,7 @@ Zone	Europe/Paris	0:09:21 -	LMT	1891 Mar 15  0:01
 # http://www.parlament-berlin.de/pds-fraktion.nsf/727459127c8b66ee8525662300459099/defc77cb784f180ac1256c2b0030274b/$FILE/bersarint.pdf
 # says that Bersarin issued an order to use Moscow time on May 20.
 # However, Moscow did not observe daylight saving in 1945, so
-# this was equivalent to CEMT (GMT+3), not GMT+4.
+# this was equivalent to UT +03, not +04.
 
 
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
@@ -2260,7 +2273,6 @@ Zone Europe/Bucharest	1:44:24 -	LMT	1891 Oct
 # http://www.worldtimezone.com/dst_news/dst_news_russia-map-2014-07.html
 
 # From Paul Eggert (2006-03-22):
-# Except for Moscow after 1919-07-01, I invented the time zone abbreviations.
 # Moscow time zone abbreviations after 1919-07-01, and Moscow rules after 1991,
 # are from Andrey A. Chernov.  The rest is from Shanks & Pottenger,
 # except we follow Chernov's report that 1992 DST transitions were Sat
@@ -2336,7 +2348,7 @@ Zone Europe/Kaliningrad	 1:22:00 -	LMT	1893 Apr
 			 2:00	Poland	CE%sT	1946
 			 3:00	Russia	MSK/MSD	1989 Mar 26  2:00s
 			 2:00	Russia	EE%sT	2011 Mar 27  2:00s
-			 3:00	-	FET	2014 Oct 26  2:00s
+			 3:00	-	+03	2014 Oct 26  2:00s
 			 2:00	-	EET
 
 
@@ -2389,6 +2401,16 @@ Zone Europe/Kaliningrad	 1:22:00 -	LMT	1893 Apr
 # 78	RU-SPE	Saint Petersburg
 # 83	RU-NEN	Nenets Autonomous Okrug
 
+# From Paul Eggert (2016-08-23):
+# The Soviets switched to UT-based time in 1919.  Decree No. 59
+# (1919-02-08) http://istmat.info/node/35567 established UT-based time
+# zones, and Decree No. 147 (1919-03-29) http://istmat.info/node/35854
+# specified a transition date of 1919-07-01, apparently at 00:00 UT.
+# No doubt only the Soviet-controlled regions switched on that date;
+# later transitions to UT-based time in other parts of Russia are
+# taken from what appear to be guesses by Shanks.
+# (Thanks to Alexander Belopolsky for pointers to the decrees.)
+
 # From Stepan Golosunov (2016-03-07):
 # 11. Regions-violators, 1981-1982.
 # Wikipedia refers to
@@ -2430,7 +2452,7 @@ Zone Europe/Kaliningrad	 1:22:00 -	LMT	1893 Apr
 # attributes the 1982 changes to the Act of the Council of Ministers
 # of the USSR No. 126 from 18.02.1982.  1980-925.txt also adds
 # Udmurtia to the list of affected territories and lists Khatangsky
-# district separately from Taymyr Autonomous Okurg.  Probably erroneously.
+# district separately from Taymyr Autonomous Okrug.  Probably erroneously.
 #
 # The affected territories are currently listed under Europe/Moscow,
 # Asia/Yekaterinburg and Asia/Krasnoyarsk.
@@ -2490,7 +2512,7 @@ Zone Europe/Kaliningrad	 1:22:00 -	LMT	1893 Apr
 
 Zone Europe/Moscow	 2:30:17 -	LMT	1880
 			 2:30:17 -	MMT	1916 Jul  3 # Moscow Mean Time
-			 2:31:19 Russia	%s	1919 Jul  1  2:00
+			 2:31:19 Russia	%s	1919 Jul  1  0:00u
 			 3:00	Russia	%s	1921 Oct
 			 3:00	Russia	MSK/MSD	1922 Oct
 			 2:00	-	EET	1930 Jun 21
@@ -2573,22 +2595,21 @@ Zone Europe/Astrakhan	 3:12:12 -	LMT	1924 May
 # The 1988 transition is from USSR act No. 5 (1988-01-04).
 
 Zone Europe/Volgograd	 2:57:40 -	LMT	1920 Jan  3
-			 3:00	-	TSAT	1925 Apr  6 # Tsaritsyn Time
-			 3:00	-	STAT	1930 Jun 21 # Stalingrad Time
-			 4:00	-	STAT	1961 Nov 11
-			 4:00	Russia	VOL%sT	1988 Mar 27  2:00s # Volgograd T
-			 3:00	Russia	VOL%sT	1991 Mar 31  2:00s
-			 4:00	-	VOLT	1992 Mar 29  2:00s
-			 3:00	Russia	MSK/MSD	2011 Mar 27  2:00s
-			 4:00	-	MSK	2014 Oct 26  2:00s
-			 3:00	-	MSK
+			 3:00	-	+03	1930 Jun 21
+			 4:00	-	+04	1961 Nov 11
+			 4:00	Russia	+04/+05	1988 Mar 27  2:00s
+			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
+			 4:00	-	+04	1992 Mar 29  2:00s
+			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
+			 4:00	-	+04	2014 Oct 26  2:00s
+			 3:00	-	+03
 
 # From Paul Eggert (2016-03-18):
 # Europe/Kirov covers:
 # 43	RU-KIR	Kirov Oblast
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
 #
-Zone Europe/Kirov	 3:18:48 -	LMT	1919 Jul  1  2:00
+Zone Europe/Kirov	 3:18:48 -	LMT	1919 Jul  1  0:00u
 			 3:00	-	+03	1930 Jun 21
 			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
 			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
@@ -2606,16 +2627,16 @@ Zone Europe/Kirov	 3:18:48 -	LMT	1919 Jul  1  2:00
 # Byalokoz 1919 says Samara was 3:20:20.
 # The 1989 transition is from USSR act No. 227 (1989-03-14).
 
-Zone Europe/Samara	 3:20:20 -	LMT	1919 Jul  1  2:00
-			 3:00	-	SAMT	1930 Jun 21 # Samara Time
-			 4:00	-	SAMT	1935 Jan 27
-			 4:00	Russia	KUY%sT	1989 Mar 26  2:00s # Kuybyshev
-			 3:00	Russia	MSK/MSD	1991 Mar 31  2:00s
-			 2:00	Russia	EE%sT	1991 Sep 29  2:00s
-			 3:00	-	SAMT	1991 Oct 20  3:00
-			 4:00	Russia	SAM%sT	2010 Mar 28  2:00s
-			 3:00	Russia	SAM%sT	2011 Mar 27  2:00s
-			 4:00	-	SAMT
+Zone Europe/Samara	 3:20:20 -	LMT	1919 Jul  1  0:00u
+			 3:00	-	+03	1930 Jun 21
+			 4:00	-	+04	1935 Jan 27
+			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
+			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
+			 2:00	Russia	+02/+03	1991 Sep 29  2:00s
+			 3:00	-	+03	1991 Oct 20  3:00
+			 4:00	Russia	+04/+05	2010 Mar 28  2:00s
+			 3:00	Russia	+03/+04	2011 Mar 27  2:00s
+			 4:00	-	+04
 
 # From Paul Eggert (2016-03-18):
 # Europe/Ulyanovsk covers:
@@ -2630,7 +2651,7 @@ Zone Europe/Samara	 3:20:20 -	LMT	1919 Jul  1  2:00
 # From Matt Johnson (2016-03-09):
 # http://publication.pravo.gov.ru/Document/View/0001201603090051
 
-Zone Europe/Ulyanovsk	 3:13:36 -	LMT	1919 Jul  1  2:00
+Zone Europe/Ulyanovsk	 3:13:36 -	LMT	1919 Jul  1  0:00u
 			 3:00	-	+03	1930 Jun 21
 			 4:00	Russia	+04/+05	1989 Mar 26  2:00s
 			 3:00	Russia	+03/+04	1991 Mar 31  2:00s
@@ -2662,12 +2683,12 @@ Zone Europe/Ulyanovsk	 3:13:36 -	LMT	1919 Jul  1  2:00
 
 Zone Asia/Yekaterinburg	 4:02:33 -	LMT	1916 Jul  3
 			 3:45:05 -	PMT	1919 Jul 15  4:00
-			 4:00	-	SVET	1930 Jun 21 # Sverdlovsk Time
-			 5:00	Russia	SVE%sT	1991 Mar 31  2:00s
-			 4:00	Russia	SVE%sT	1992 Jan 19  2:00s
-			 5:00	Russia	YEK%sT	2011 Mar 27  2:00s
-			 6:00	-	YEKT	2014 Oct 26  2:00s
-			 5:00	-	YEKT
+			 4:00	-	+04	1930 Jun 21
+			 5:00	Russia	+05/+06	1991 Mar 31  2:00s
+			 4:00	Russia	+04/+05	1992 Jan 19  2:00s
+			 5:00	Russia	+05/+06	2011 Mar 27  2:00s
+			 6:00	-	+06	2014 Oct 26  2:00s
+			 5:00	-	+05
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
@@ -2677,12 +2698,12 @@ Zone Asia/Yekaterinburg	 4:02:33 -	LMT	1916 Jul  3
 # Byalokoz 1919 says Omsk was 4:53:30.
 
 Zone Asia/Omsk		 4:53:30 -	LMT	1919 Nov 14
-			 5:00	-	OMST	1930 Jun 21 # Omsk Time
-			 6:00	Russia	OMS%sT	1991 Mar 31  2:00s
-			 5:00	Russia	OMS%sT	1992 Jan 19  2:00s
-			 6:00	Russia	OMS%sT	2011 Mar 27  2:00s
-			 7:00	-	OMST	2014 Oct 26  2:00s
-			 6:00	-	OMST
+			 5:00	-	+05	1930 Jun 21
+			 6:00	Russia	+06/+07	1991 Mar 31  2:00s
+			 5:00	Russia	+05/+06	1992 Jan 19  2:00s
+			 6:00	Russia	+06/+07	2011 Mar 27  2:00s
+			 7:00	-	+07	2014 Oct 26  2:00s
+			 6:00	-	+06
 
 # From Paul Eggert (2016-02-22):
 # Asia/Barnaul covers:
@@ -2762,7 +2783,7 @@ Zone Asia/Novosibirsk	 5:31:40 -	LMT	1919 Dec 14  6:00
 # Note that time belts (numbered from 2 (Moscow) to 12 according to their
 # GMT/UTC offset and having too many exceptions like regions formally
 # belonging to one belt but using time from another) were replaced
-# with time zones in 2011 with different numberings (there was a
+# with time zones in 2011 with different numbering (there was a
 # 2-hour gap between second and third zones in 2011-2014).
 
 # From Stepan Golosunov (2016-04-12):
@@ -2845,12 +2866,12 @@ Zone Asia/Novokuznetsk	 5:48:48 -	LMT	1924 May  1
 # Byalokoz 1919 says Krasnoyarsk was 6:11:26.
 
 Zone Asia/Krasnoyarsk	 6:11:26 -	LMT	1920 Jan  6
-			 6:00	-	KRAT	1930 Jun 21 # Krasnoyarsk Time
-			 7:00	Russia	KRA%sT	1991 Mar 31  2:00s
-			 6:00	Russia	KRA%sT	1992 Jan 19  2:00s
-			 7:00	Russia	KRA%sT	2011 Mar 27  2:00s
-			 8:00	-	KRAT	2014 Oct 26  2:00s
-			 7:00	-	KRAT
+			 6:00	-	+06	1930 Jun 21
+			 7:00	Russia	+07/+08	1991 Mar 31  2:00s
+			 6:00	Russia	+06/+07	1992 Jan 19  2:00s
+			 7:00	Russia	+07/+08	2011 Mar 27  2:00s
+			 8:00	-	+08	2014 Oct 26  2:00s
+			 7:00	-	+07
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
@@ -2867,12 +2888,12 @@ Zone Asia/Krasnoyarsk	 6:11:26 -	LMT	1920 Jan  6
 
 Zone Asia/Irkutsk	 6:57:05 -	LMT	1880
 			 6:57:05 -	IMT	1920 Jan 25 # Irkutsk Mean Time
-			 7:00	-	IRKT	1930 Jun 21 # Irkutsk Time
-			 8:00	Russia	IRK%sT	1991 Mar 31  2:00s
-			 7:00	Russia	IRK%sT	1992 Jan 19  2:00s
-			 8:00	Russia	IRK%sT	2011 Mar 27  2:00s
-			 9:00	-	IRKT	2014 Oct 26  2:00s
-			 8:00	-	IRKT
+			 7:00	-	+07	1930 Jun 21
+			 8:00	Russia	+08/+09	1991 Mar 31  2:00s
+			 7:00	Russia	+07/+08	1992 Jan 19  2:00s
+			 8:00	Russia	+08/+09	2011 Mar 27  2:00s
+			 9:00	-	+09	2014 Oct 26  2:00s
+			 8:00	-	+08
 
 
 # From Tim Parenti (2014-07-06):
@@ -2889,13 +2910,13 @@ Zone Asia/Irkutsk	 6:57:05 -	LMT	1880
 # http://publication.pravo.gov.ru/Document/View/0001201512300107
 
 Zone Asia/Chita	 7:33:52 -	LMT	1919 Dec 15
-			 8:00	-	YAKT	1930 Jun 21 # Yakutsk Time
-			 9:00	Russia	YAK%sT	1991 Mar 31  2:00s
-			 8:00	Russia	YAK%sT	1992 Jan 19  2:00s
-			 9:00	Russia	YAK%sT	2011 Mar 27  2:00s
-			10:00	-	YAKT	2014 Oct 26  2:00s
-			 8:00	-	IRKT	2016 Mar 27  2:00
-			 9:00	-	YAKT
+			 8:00	-	+08	1930 Jun 21
+			 9:00	Russia	+09/+10	1991 Mar 31  2:00s
+			 8:00	Russia	+08/+09	1992 Jan 19  2:00s
+			 9:00	Russia	+09/+10	2011 Mar 27  2:00s
+			10:00	-	+10	2014 Oct 26  2:00s
+			 8:00	-	+08	2016 Mar 27  2:00
+			 9:00	-	+09
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2009-11-29):
@@ -2935,12 +2956,12 @@ Zone Asia/Chita	 7:33:52 -	LMT	1919 Dec 15
 # Byalokoz 1919 says Yakutsk was 8:38:58.
 
 Zone Asia/Yakutsk	 8:38:58 -	LMT	1919 Dec 15
-			 8:00	-	YAKT	1930 Jun 21 # Yakutsk Time
-			 9:00	Russia	YAK%sT	1991 Mar 31  2:00s
-			 8:00	Russia	YAK%sT	1992 Jan 19  2:00s
-			 9:00	Russia	YAK%sT	2011 Mar 27  2:00s
-			10:00	-	YAKT	2014 Oct 26  2:00s
-			 9:00	-	YAKT
+			 8:00	-	+08	1930 Jun 21
+			 9:00	Russia	+09/+10	1991 Mar 31  2:00s
+			 8:00	Russia	+08/+09	1992 Jan 19  2:00s
+			 9:00	Russia	+09/+10	2011 Mar 27  2:00s
+			10:00	-	+10	2014 Oct 26  2:00s
+			 9:00	-	+09
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2009-11-29):
@@ -2958,12 +2979,12 @@ Zone Asia/Yakutsk	 8:38:58 -	LMT	1919 Dec 15
 # Go with Byalokoz.
 
 Zone Asia/Vladivostok	 8:47:31 -	LMT	1922 Nov 15
-			 9:00	-	VLAT	1930 Jun 21 # Vladivostok Time
-			10:00	Russia	VLA%sT	1991 Mar 31  2:00s
-			 9:00	Russia	VLA%sT	1992 Jan 19  2:00s
-			10:00	Russia	VLA%sT	2011 Mar 27  2:00s
-			11:00	-	VLAT	2014 Oct 26  2:00s
-			10:00	-	VLAT
+			 9:00	-	+09	1930 Jun 21
+			10:00	Russia	+10/+11	1991 Mar 31  2:00s
+			 9:00	Russia	+09/+10	1992 Jan 19  2:00s
+			10:00	Russia	+10/+11	2011 Mar 27  2:00s
+			11:00	-	+11	2014 Oct 26  2:00s
+			10:00	-	+10
 
 
 # From Tim Parenti (2014-07-03):
@@ -2981,14 +3002,14 @@ Zone Asia/Vladivostok	 8:47:31 -	LMT	1922 Nov 15
 # This transition is no doubt wrong, but we have no better info.
 
 Zone Asia/Khandyga	 9:02:13 -	LMT	1919 Dec 15
-			 8:00	-	YAKT	1930 Jun 21 # Yakutsk Time
-			 9:00	Russia	YAK%sT	1991 Mar 31  2:00s
-			 8:00	Russia	YAK%sT	1992 Jan 19  2:00s
-			 9:00	Russia	YAK%sT	2004
-			10:00	Russia	VLA%sT	2011 Mar 27  2:00s
-			11:00	-	VLAT	2011 Sep 13  0:00s # Decree 725?
-			10:00	-	YAKT	2014 Oct 26  2:00s
-			 9:00	-	YAKT
+			 8:00	-	+08	1930 Jun 21
+			 9:00	Russia	+09/+10	1991 Mar 31  2:00s
+			 8:00	Russia	+08/+09	1992 Jan 19  2:00s
+			 9:00	Russia	+09/+10	2004
+			10:00	Russia	+10/+11	2011 Mar 27  2:00s
+			11:00	-	+11	2011 Sep 13  0:00s # Decree 725?
+			10:00	-	+10	2014 Oct 26  2:00s
+			 9:00	-	+09
 
 
 # From Tim Parenti (2014-07-03):
@@ -3004,15 +3025,14 @@ Zone Asia/Khandyga	 9:02:13 -	LMT	1919 Dec 15
 
 # The Zone name should be Asia/Yuzhno-Sakhalinsk, but that's too long.
 Zone Asia/Sakhalin	 9:30:48 -	LMT	1905 Aug 23
-			 9:00	-	JCST	1937 Oct  1
-			 9:00	-	JST	1945 Aug 25
-			11:00	Russia	SAK%sT	1991 Mar 31  2:00s # Sakhalin T
-			10:00	Russia	SAK%sT	1992 Jan 19  2:00s
-			11:00	Russia	SAK%sT	1997 Mar lastSun  2:00s
-			10:00	Russia	SAK%sT	2011 Mar 27  2:00s
-			11:00	-	SAKT	2014 Oct 26  2:00s
-			10:00	-	SAKT	2016 Mar 27  2:00s
-			11:00	-	SAKT
+			 9:00	-	+09	1945 Aug 25
+			11:00	Russia	+11/+12	1991 Mar 31  2:00s # Sakhalin T
+			10:00	Russia	+10/+11	1992 Jan 19  2:00s
+			11:00	Russia	+11/+12	1997 Mar lastSun  2:00s
+			10:00	Russia	+10/+11	2011 Mar 27  2:00s
+			11:00	-	+11	2014 Oct 26  2:00s
+			10:00	-	+10	2016 Mar 27  2:00s
+			11:00	-	+11
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2009-11-29):
@@ -3035,13 +3055,13 @@ Zone Asia/Sakhalin	 9:30:48 -	LMT	1905 Aug 23
 # http://publication.pravo.gov.ru/Document/View/0001201604050038
 
 Zone Asia/Magadan	10:03:12 -	LMT	1924 May  2
-			10:00	-	MAGT	1930 Jun 21 # Magadan Time
-			11:00	Russia	MAG%sT	1991 Mar 31  2:00s
-			10:00	Russia	MAG%sT	1992 Jan 19  2:00s
-			11:00	Russia	MAG%sT	2011 Mar 27  2:00s
-			12:00	-	MAGT	2014 Oct 26  2:00s
-			10:00	-	MAGT	2016 Apr 24  2:00s
-			11:00	-	MAGT
+			10:00	-	+10	1930 Jun 21 # Magadan Time
+			11:00	Russia	+11/+12	1991 Mar 31  2:00s
+			10:00	Russia	+10/+11	1992 Jan 19  2:00s
+			11:00	Russia	+11/+12	2011 Mar 27  2:00s
+			12:00	-	+12	2014 Oct 26  2:00s
+			10:00	-	+10	2016 Apr 24  2:00s
+			11:00	-	+11
 
 
 # From Tim Parenti (2014-07-06):
@@ -3084,17 +3104,14 @@ Zone Asia/Magadan	10:03:12 -	LMT	1924 May  2
 # in Russian.)  In addition, Srednekolymsk appears to be a much older
 # settlement and the population of Zyryanka seems to be declining.
 # Go with Srednekolymsk.
-#
-# Since Magadan Oblast moves to UTC+10 on 2014-10-26, we cannot keep using MAGT
-# as the abbreviation.  Use SRET instead.
 
 Zone Asia/Srednekolymsk	10:14:52 -	LMT	1924 May  2
-			10:00	-	MAGT	1930 Jun 21 # Magadan Time
-			11:00	Russia	MAG%sT	1991 Mar 31  2:00s
-			10:00	Russia	MAG%sT	1992 Jan 19  2:00s
-			11:00	Russia	MAG%sT	2011 Mar 27  2:00s
-			12:00	-	MAGT	2014 Oct 26  2:00s
-			11:00	-	SRET	# Srednekolymsk Time
+			10:00	-	+10	1930 Jun 21
+			11:00	Russia	+11/+12	1991 Mar 31  2:00s
+			10:00	Russia	+10/+11	1992 Jan 19  2:00s
+			11:00	Russia	+11/+12	2011 Mar 27  2:00s
+			12:00	-	+12	2014 Oct 26  2:00s
+			11:00	-	+11
 
 
 # From Tim Parenti (2014-07-03):
@@ -3112,14 +3129,14 @@ Zone Asia/Srednekolymsk	10:14:52 -	LMT	1924 May  2
 # UTC+12 since at least then, too.
 
 Zone Asia/Ust-Nera	 9:32:54 -	LMT	1919 Dec 15
-			 8:00	-	YAKT	1930 Jun 21 # Yakutsk Time
-			 9:00	Russia	YAKT	1981 Apr  1
-			11:00	Russia	MAG%sT	1991 Mar 31  2:00s
-			10:00	Russia	MAG%sT	1992 Jan 19  2:00s
-			11:00	Russia	MAG%sT	2011 Mar 27  2:00s
-			12:00	-	MAGT	2011 Sep 13  0:00s # Decree 725?
-			11:00	-	VLAT	2014 Oct 26  2:00s
-			10:00	-	VLAT
+			 8:00	-	+08	1930 Jun 21
+			 9:00	Russia	+09/+10	1981 Apr  1
+			11:00	Russia	+11/+12	1991 Mar 31  2:00s
+			10:00	Russia	+10/+11	1992 Jan 19  2:00s
+			11:00	Russia	+11/+12	2011 Mar 27  2:00s
+			12:00	-	+12	2011 Sep 13  0:00s # Decree 725?
+			11:00	-	+11	2014 Oct 26  2:00s
+			10:00	-	+10
 
 
 # From Tim Parenti (2014-07-03), per Oscar van Vlijmen (2001-08-25):
@@ -3132,12 +3149,12 @@ Zone Asia/Ust-Nera	 9:32:54 -	LMT	1919 Dec 15
 # The Zone name should be Asia/Petropavlovsk-Kamchatski or perhaps
 # Asia/Petropavlovsk-Kamchatsky, but these are too long.
 Zone Asia/Kamchatka	10:34:36 -	LMT	1922 Nov 10
-			11:00	-	PETT	1930 Jun 21 # P-K Time
-			12:00	Russia	PET%sT	1991 Mar 31  2:00s
-			11:00	Russia	PET%sT	1992 Jan 19  2:00s
-			12:00	Russia	PET%sT	2010 Mar 28  2:00s
-			11:00	Russia	PET%sT	2011 Mar 27  2:00s
-			12:00	-	PETT
+			11:00	-	+11	1930 Jun 21
+			12:00	Russia	+12/+13	1991 Mar 31  2:00s
+			11:00	Russia	+11/+12	1992 Jan 19  2:00s
+			12:00	Russia	+12/+13	2010 Mar 28  2:00s
+			11:00	Russia	+11/+12	2011 Mar 27  2:00s
+			12:00	-	+12
 
 
 # From Tim Parenti (2014-07-03):
@@ -3145,13 +3162,13 @@ Zone Asia/Kamchatka	10:34:36 -	LMT	1922 Nov 10
 # 87	RU-CHU	Chukotka Autonomous Okrug
 
 Zone Asia/Anadyr	11:49:56 -	LMT	1924 May  2
-			12:00	-	ANAT	1930 Jun 21 # Anadyr Time
-			13:00	Russia	ANA%sT	1982 Apr  1  0:00s
-			12:00	Russia	ANA%sT	1991 Mar 31  2:00s
-			11:00	Russia	ANA%sT	1992 Jan 19  2:00s
-			12:00	Russia	ANA%sT	2010 Mar 28  2:00s
-			11:00	Russia	ANA%sT	2011 Mar 27  2:00s
-			12:00	-	ANAT
+			12:00	-	+12	1930 Jun 21
+			13:00	Russia	+13/+14	1982 Apr  1  0:00s
+			12:00	Russia	+12/+13	1991 Mar 31  2:00s
+			11:00	Russia	+11/+12	1992 Jan 19  2:00s
+			12:00	Russia	+12/+13	2010 Mar 28  2:00s
+			11:00	Russia	+11/+12	2011 Mar 27  2:00s
+			12:00	-	+12
 
 
 # San Marino
@@ -3472,6 +3489,14 @@ Zone	Europe/Zurich	0:34:08 -	LMT	1853 Jul 16 # See above comment.
 # Engineered Standard Time," said Twitter user @aysekarahasan.
 # http://www.bbc.com/news/world-europe-34631326
 
+# From Burak AYDIN (2016-09-08):
+# Turkey will stay in Daylight Saving Time even in winter....
+# http://www.resmigazete.gov.tr/eskiler/2016/09/20160908-2.pdf
+#
+# From Paul Eggert (2016-09-07):
+# The change is permanent, so this is the new standard time in Turkey.
+# It takes effect today, which is not much notice.
+
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER/S
 Rule	Turkey	1916	only	-	May	 1	0:00	1:00	S
 Rule	Turkey	1916	only	-	Oct	 1	0:00	0	-
@@ -3535,7 +3560,7 @@ Rule	Turkey	1996	2006	-	Oct	lastSun	1:00s	0	-
 Zone	Europe/Istanbul	1:55:52 -	LMT	1880
 			1:56:56	-	IMT	1910 Oct # Istanbul Mean Time?
 			2:00	Turkey	EE%sT	1978 Oct 15
-			3:00	Turkey	TR%sT	1985 Apr 20 # Turkey Time
+			3:00	Turkey	+03/+04	1985 Apr 20
 			2:00	Turkey	EE%sT	2007
 			2:00	EU	EE%sT	2011 Mar 27  1:00u
 			2:00	-	EET	2011 Mar 28  1:00u
@@ -3543,7 +3568,8 @@ Zone	Europe/Istanbul	1:55:52 -	LMT	1880
 			2:00	-	EET	2014 Mar 31  1:00u
 			2:00	EU	EE%sT	2015 Oct 25  1:00u
 			2:00	1:00	EEST	2015 Nov  8  1:00u
-			2:00	EU	EE%sT
+			2:00	EU	EE%sT	2016 Sep  7
+			3:00	-	+03
 Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 
 # Ukraine

--- a/src/main/java/org/joda/time/tz/src/northamerica
+++ b/src/main/java/org/joda/time/tz/src/northamerica
@@ -413,11 +413,42 @@ Zone America/Denver	-6:59:56 -	LMT	1883 Nov 18 12:00:04
 # north of the Salmon River, and the towns of Burgdorf and Warren),
 # Nevada (except West Wendover), Oregon (except the northern 3/4 of
 # Malheur county), and Washington
+
+# From Paul Eggert (2016-08-20):
+# In early February 1948, in response to California's electricity shortage,
+# PG&E changed power frequency from 60 to 59.5 Hz during daylight hours,
+# causing electric clocks to lose six minutes per day.  (This did not change
+# legal time, and is not part of the data here.)  See:
+# Ross SA. An energy crisis from the past: Northern California in 1948.
+# Working Paper No. 8, Institute of Governmental Studies, UC Berkeley,
+# 1973-11.  http://escholarship.org/uc/item/8x22k30c
+#
+# In another measure to save electricity, DST was instituted from 1948-03-14
+# at 02:01 to 1949-01-16 at 02:00, with the governor having the option to move
+# the fallback transition earlier.  See pages 3-4 of:
+# http://clerk.assembly.ca.gov/sites/clerk.assembly.ca.gov/files/archive/Statutes/1948/48Vol1_Chapters.pdf
+#
+# In response:
+#
+#   Governor Warren received a torrent of objecting mail, and it is not too much
+#   to speculate that the objections to Daylight Saving Time were one important
+#   factor in the defeat of the Dewey-Warren Presidential ticket in California.
+#     -- Ross, p 25
+#
+# On December 8 the governor exercised the option, setting the date to January 1
+# (LA Times 1948-12-09).  The transition time was 02:00 (LA Times 1949-01-01).
+#
+# Despite the controversy, in 1949 California voters approved Proposition 12,
+# which established DST from April's last Sunday at 01:00 until September's
+# last Sunday at 02:00. This was amended by 1962's Proposition 6, which changed
+# the fall-back date to October's last Sunday. See:
+# http://repository.uchastings.edu/cgi/viewcontent.cgi?article=1501&context=ca_ballot_props
+# http://repository.uchastings.edu/cgi/viewcontent.cgi?article=1636&context=ca_ballot_props
 #
 # Rule	NAME	FROM	TO	TYPE	IN	ON	AT	SAVE	LETTER
-Rule	CA	1948	only	-	Mar	14	2:00	1:00	D
+Rule	CA	1948	only	-	Mar	14	2:01	1:00	D
 Rule	CA	1949	only	-	Jan	 1	2:00	0	S
-Rule	CA	1950	1966	-	Apr	lastSun	2:00	1:00	D
+Rule	CA	1950	1966	-	Apr	lastSun	1:00	1:00	D
 Rule	CA	1950	1961	-	Sep	lastSun	2:00	0	S
 Rule	CA	1962	1966	-	Oct	lastSun	2:00	0	S
 # Zone	NAME		GMTOFF	RULES	FORMAT	[UNTIL]
@@ -3281,7 +3312,7 @@ Zone America/Miquelon	-3:44:40 -	LMT	1911 May 15 # St Pierre
 # indicating that the normal ET rules are followed.
 #
 # From Paul Eggert (2014-08-19):
-# The 2014-08-13 Cabinet meeting decided to stay on UTC-4 year-round.  See:
+# The 2014-08-13 Cabinet meeting decided to stay on UT -04 year-round.  See:
 # http://tcweeklynews.com/daylight-savings-time-to-be-maintained-p5353-127.htm
 # Model this as a switch from EST/EDT to AST ...
 # From Chris Walton (2014-11-04):

--- a/src/main/java/org/joda/time/tz/src/southamerica
+++ b/src/main/java/org/joda/time/tz/src/southamerica
@@ -410,9 +410,9 @@ Rule	Arg	2008	only	-	Oct	Sun>=15	0:00	1:00	S
 # stuck on Summer daylight savings time even though the summer is over.
 
 # From Paul Eggert (2013-09-05):
-# Perhaps San Luis operates on the legal fiction that it is at UTC-4
+# Perhaps San Luis operates on the legal fiction that it is at -04
 # with perpetual summer time, but ordinary usage typically seems to
-# just say it's at UTC-3; see, for example,
+# just say it's at -03; see, for example,
 # http://es.wikipedia.org/wiki/Hora_oficial_argentina
 # We've documented similar situations as being plain changes to
 # standard time, so let's do that here too.  This does not change UTC


### PR DESCRIPTION
Turkey recently switched to DST permanently, i.e. is going to remain on UTC+3 all year round. Latest version of the database addresses this.