### PR TITLE
Cleaner AbstractInterval.checkInterval error msg

### DIFF
--- a/src/main/java/org/joda/time/base/AbstractInterval.java
+++ b/src/main/java/org/joda/time/base/AbstractInterval.java
@@ -60,7 +60,7 @@ public abstract class AbstractInterval implements ReadableInterval {
      */
     protected void checkInterval(long start, long end) {
         if (end < start) {
-            throw new IllegalArgumentException("The end instant must be greater the start");
+            throw new IllegalArgumentException("The end instant must be greater than the start instant");
         }
     }
 


### PR DESCRIPTION
2.8.3 updated this message to more accurately reflect the check being done (which was great), but the update made the error message less human-friendly and grammatically incorrect.