### PR TITLE
Add ZoneInfoProvider() constructor

### DIFF
--- a/src/main/java/org/joda/time/DateTimeZone.java
+++ b/src/main/java/org/joda/time/DateTimeZone.java
@@ -127,6 +127,11 @@ public abstract class DateTimeZone implements Serializable {
      */
     private static final AtomicReference<DateTimeZone> cDefault =
                     new AtomicReference<DateTimeZone>();
+    /**
+     * The default TZ data path
+     * This is the default classpath location containing the compiled data files.
+     */
+    public static final String DEFAULT_TZ_DATA_PATH = "org/joda/time/tz/data";
 
     //-----------------------------------------------------------------------
     /**
@@ -529,7 +534,7 @@ public abstract class DateTimeZone implements Serializable {
         }
         // approach 3
         try {
-            Provider provider = new ZoneInfoProvider("org/joda/time/tz/data");
+            Provider provider = new ZoneInfoProvider(DEFAULT_TZ_DATA_PATH);
             return validateProvider(provider);
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/src/main/java/org/joda/time/tz/ZoneInfoProvider.java
+++ b/src/main/java/org/joda/time/tz/ZoneInfoProvider.java
@@ -54,6 +54,15 @@ public class ZoneInfoProvider implements Provider {
     private final Set<String> iZoneInfoKeys;
 
     /**
+     * Search the default classloader resource path for compiled data files.
+     *
+     * @throws IOException if directory or map file cannot be read
+     */
+    public ZoneInfoProvider() throws IOException {
+        this(DateTimeZone.DEFAULT_TZ_DATA_PATH);
+    }
+
+    /**
      * ZoneInfoProvider searches the given directory for compiled data files.
      *
      * @throws IOException if directory or map file cannot be read


### PR DESCRIPTION
As there is no ZoneInfoProvider() constructor, it is not possible to
specify org.joda.time.tz.ZoneInfoProvider with the system property
org.joda.time.DateTimeZone.Provider; this patch addresses this.

The Joda-Time project has been running for many years now, and the codebase is stable.
Java SE 8 contains a new date and time library that is the successor to Joda-Time.
As such Joda-Time is primarily in maintainence mode and few pull requests are likely to be merged.