### PR TITLE
Fix title of Ethiopic calendar doc page

### DIFF
--- a/src/site/xdoc/cal_ethiopic.xml
+++ b/src/site/xdoc/cal_ethiopic.xml
@@ -3,7 +3,7 @@
 <document>
 
  <properties>
-  <title>Java date and time API - Coptic calendar system</title>
+  <title>Java date and time API - Ethiopic calendar system</title>
   <author>Stephen Colebourne</author>
  </properties>
 


### PR DESCRIPTION
Looks like the title of this page wasn't updated when copying the documentation template from Coptic calendar docs.