### PR TITLE
Add `Instant.ofEpochMilli(long epochMilli)` and `Instant.ofEpochSecond(long epochSecond)`

### DIFF
--- a/src/main/java/org/joda/time/Instant.java
+++ b/src/main/java/org/joda/time/Instant.java
@@ -72,6 +72,26 @@ public final class Instant
     public static Instant now() {
         return new Instant();
     }
+    
+    /**
+     * Obtains an {@code Instant} set to the milliseconds from 1970-01-01T00:00:00Z.
+     * 
+     * @param epochMilli  the milliseconds from 1970-01-01T00:00:00Z
+     * @since 3.0
+     */
+    public static Instant ofEpochMilli(long epochMilli) {
+        return new Instant(epochMilli);
+    }
+    
+    /**
+     * Obtains an {@code Instant} set to the seconds from 1970-01-01T00:00:00Z.
+     * 
+     * @param epochSecond  the seconds from 1970-01-01T00:00:00Z
+     * @since 3.0
+     */
+    public static Instant ofEpochSecond(long epochSecond) {
+        return new Instant(epochSecond * 1000);
+    }
 
     //-----------------------------------------------------------------------
     /**

--- a/src/main/java/org/joda/time/Instant.java
+++ b/src/main/java/org/joda/time/Instant.java
@@ -22,6 +22,7 @@ import org.joda.time.base.AbstractInstant;
 import org.joda.time.chrono.ISOChronology;
 import org.joda.time.convert.ConverterManager;
 import org.joda.time.convert.InstantConverter;
+import org.joda.time.field.FieldUtils;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
@@ -87,10 +88,11 @@ public final class Instant
      * Obtains an {@code Instant} set to the seconds from 1970-01-01T00:00:00Z.
      * 
      * @param epochSecond  the seconds from 1970-01-01T00:00:00Z
+     * @throws ArithmeticException if the new instant exceeds the capacity of a long
      * @since 3.0
      */
     public static Instant ofEpochSecond(long epochSecond) {
-        return new Instant(epochSecond * 1000);
+        return new Instant(FieldUtils.safeMultiply(epochSecond, 1000));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/joda/time/TestInstant_Constructors.java
+++ b/src/test/java/org/joda/time/TestInstant_Constructors.java
@@ -96,6 +96,22 @@ public class TestInstant_Constructors extends TestCase {
     }
 
     //-----------------------------------------------------------------------
+    /**
+     * Test ofEpochMilli() and ofEpochSecond()
+     */
+    public void test_ofEpochMilli() throws Throwable {
+        Instant test = Instant.ofEpochMilli(TEST_TIME1);
+        assertEquals(ISOChronology.getInstanceUTC(), test.getChronology());
+        assertEquals(TEST_TIME1, test.getMillis());
+    }
+    
+    public void test_ofEpochSecond() throws Throwable {
+        Instant test = Instant.ofEpochSecond(TEST_TIME1 / 1000);
+        assertEquals(ISOChronology.getInstanceUTC(), test.getChronology());
+        assertEquals(TEST_TIME1, test.getMillis());
+    }
+
+    //-----------------------------------------------------------------------
     public void testParse_noFormatter() throws Throwable {
         assertEquals(new DateTime(2010, 6, 30, 0, 20, ISOChronology.getInstance(LONDON)).toInstant(), Instant.parse("2010-06-30T01:20+02:00"));
         assertEquals(new DateTime(2010, 1, 2, 14, 50, ISOChronology.getInstance(LONDON)).toInstant(), Instant.parse("2010-002T14:50"));

--- a/src/test/java/org/joda/time/TestInstant_Constructors.java
+++ b/src/test/java/org/joda/time/TestInstant_Constructors.java
@@ -110,6 +110,25 @@ public class TestInstant_Constructors extends TestCase {
         assertEquals(ISOChronology.getInstanceUTC(), test.getChronology());
         assertEquals(TEST_TIME1, test.getMillis());
     }
+    
+    public void test_ofEpochSecond_zero() throws Throwable {
+        Instant test = Instant.ofEpochSecond(0);
+        assertEquals(0, test.getMillis());
+    }
+    
+    public void test_ofEpochSecond_overflow() throws Throwable {
+        try {
+            Instant.ofEpochSecond(Long.MAX_VALUE);
+            fail();
+        } catch (ArithmeticException ex) {}
+    }
+    
+    public void test_ofEpochSecond_underflow() throws Throwable {
+        try {
+            Instant.ofEpochSecond(Long.MIN_VALUE);
+            fail();
+        } catch (ArithmeticException ex) {}
+    }
 
     //-----------------------------------------------------------------------
     public void testParse_noFormatter() throws Throwable {


### PR DESCRIPTION
Add `Instant.ofEpochMilli(long epochMilli)` and `Instant.ofEpochSecond(long epochSecond)`

Fixes https://github.com/JodaOrg/joda-time/issues/445