### PR TITLE
Indicate the library is not actively developed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Joda-Time
 Joda-Time provides a quality replacement for the Java date and time classes.
 The design allows for multiple calendar systems, while still providing a simple API.
 The 'default' calendar is the ISO8601 standard which is used by XML.
-The Gregorian, Julian, Buddhist, Coptic, Ethiopic and Islamic systems are also included, and we welcome further additions.
+The Gregorian, Julian, Buddhist, Coptic, Ethiopic and Islamic systems are also included.
 Supporting classes include time zone, duration, format and parsing. 
+
+**Joda-time is no longer in active development except to keep timezone data up to date.** From Java SE 8 onwards, users are asked to migrate to `java.time` (JSR-310) - a core part of the JDK which replaces this project. For Android users, `java.time` is [added in API 26+](https://developer.android.com/reference/java/time/package-summary). Projects needing to support lower API levels can use [the ThreeTenABP library](https://github.com/JakeWharton/ThreeTenABP).
 
 As a flavour of Joda-Time, here's some example code:
 


### PR DESCRIPTION
The project home page and pull request template indicate that the library is no longer under active development but the README currently shows no indication of this which could lead to wasted effort (e.g. #479). 

The README should certainly not state that calendaring system additions are welcome!