### PR TITLE
Fixed Typo in Period Constructor

### DIFF
--- a/src/main/java/org/joda/time/Period.java
+++ b/src/main/java/org/joda/time/Period.java
@@ -107,7 +107,7 @@ public final class Period
      * @return the period
      */
     public static Period years(int years) {
-        return new Period(new int[] {years, 0, 0, 0, 0, 0, 0, 0, 0}, PeriodType.standard());
+        return new Period(new int[] {years, 0, 0, 0, 0, 0, 0, 0}, PeriodType.standard());
     }
 
     /**


### PR DESCRIPTION
Fixed a possible type in Period constructor. This doesn't seem to have any negative impact for now.

* Removed 9th element in Period init array