### PR TITLE
Remove extra whitespace in weekyearOfCentury declaration

### DIFF
--- a/src/main/java/org/joda/time/Chronology.java
+++ b/src/main/java/org/joda/time/Chronology.java
@@ -415,7 +415,7 @@ public abstract class Chronology {
      * 
      * @return DateTimeField or UnsupportedDateTimeField if unsupported
      */
-    public abstract  DateTimeField weekyearOfCentury();
+    public abstract DateTimeField weekyearOfCentury();
 
     // Month
     //-----------------------------------------------------------------------


### PR DESCRIPTION
The Joda-Time project has been running for many years now, and the codebase is stable.
Java SE 8 contains a new date and time library that is the successor to Joda-Time.
As such Joda-Time is primarily in maintainence mode and few pull requests are likely to be merged.

**As a general rule, most enhancement PRs will now be rejected.**

To save wasted effort, it is recommended that an issue is raised first.
The issue should clearly indicate that a PR is intended, and request approval for the work.

If you still want to raise a PR, please delete this text!
