### PR TITLE
Using the correct spelling for the capital of Ukraine (Kyiv instead of Kiev).

### DIFF
--- a/src/main/java/org/joda/time/tz/src/europe
+++ b/src/main/java/org/joda/time/tz/src/europe
@@ -4006,6 +4006,16 @@ Link	Europe/Istanbul	Asia/Istanbul	# Istanbul is in both continents.
 
 # Ukraine
 #
+# According to the Ukrainian local and international law, correct name of the
+# "Kiev" is "Kyiv".
+#
+# Reference materials:
+# - Local: Resolution No 55 of 27.01.2010 of the Cabinet of Ministers of Ukraine
+#   "On regulation of transliteration of Ukrainian alphabet by means of Latin
+#   alphabet".
+# - Global: https://unstats.un.org/UNSD/geoinfo/UNGEGN/docs/10th-uncsgn-docs/econf/E_CONF.101_85_Standardization%20of%20Geographical%20Names%20_eng.pdf
+# - Wikipedia: https://en.wikipedia.org/wiki/KyivNotKiev
+
 # From Igor Karpov, who works for the Ukrainian Ministry of Justice,
 # via Garrett Wollman (2003-01-27):
 # BTW, I've found the official document on this matter. It's government

--- a/src/site/xdoc/timezones.xml
+++ b/src/site/xdoc/timezones.xml
@@ -315,7 +315,7 @@ This table can be rebuilt by running <code>org.joda.example.time.TimeZoneTable</
 <tr><td align="left" valign="top">+02:00</td><td align="left" valign="top">Europe/Chisinau</td><td align="left" valign="top">Europe/Tiraspol</td></tr>
 <tr><td align="left" valign="top">+02:00</td><td align="left" valign="top">Europe/Helsinki</td><td align="left" valign="top"></td></tr>
 <tr><td align="left" valign="top">+02:00</td><td align="left" valign="top">Europe/Kaliningrad</td><td align="left" valign="top"></td></tr>
-<tr><td align="left" valign="top">+02:00</td><td align="left" valign="top">Europe/Kiev</td><td align="left" valign="top"></td></tr>
+<tr><td align="left" valign="top">+02:00</td><td align="left" valign="top">Europe/Kyiv</td><td align="left" valign="top"></td></tr>
 <tr><td align="left" valign="top">+02:00</td><td align="left" valign="top">Europe/Mariehamn</td><td align="left" valign="top"></td></tr>
 <tr><td align="left" valign="top">+02:00</td><td align="left" valign="top">Europe/Nicosia</td><td align="left" valign="top"></td></tr>
 <tr><td align="left" valign="top">+02:00</td><td align="left" valign="top">Europe/Riga</td><td align="left" valign="top"></td></tr>


### PR DESCRIPTION
Resolves #571 

Using the correct spelling for the capital of Ukraine (Kyiv instead of Kiev).