### PR TITLE
Fix bug in ZoneInfoCompiler.writeZoneInfoMap()

### DIFF
--- a/src/main/java/org/joda/time/tz/ZoneInfoCompiler.java
+++ b/src/main/java/org/joda/time/tz/ZoneInfoCompiler.java
@@ -168,7 +168,7 @@ public class ZoneInfoCompiler {
                 Short index = Short.valueOf(count);
                 idToIndex.put(id, index);
                 indexToId.put(index, id);
-                if (++count == Integer.MAX_VALUE) {
+                if (++count == Short.MAX_VALUE) {
                     throw new InternalError("Too many time zone ids");
                 }
             }
@@ -177,7 +177,7 @@ public class ZoneInfoCompiler {
                 Short index = Short.valueOf(count);
                 idToIndex.put(id, index);
                 indexToId.put(index, id);
-                if (++count == Integer.MAX_VALUE) {
+                if (++count == Short.MAX_VALUE) {
                     throw new InternalError("Too many time zone ids");
                 }
             }


### PR DESCRIPTION
`count` is a `short`, so it should be compared against `Short.MAX_VALUE`, not `Integer.MAX_VALUE`.

The Joda-Time project has been running for many years now, and the codebase is stable.
Java SE 8 contains a new date and time library that is the successor to Joda-Time.
As such Joda-Time is primarily in maintenance mode and few pull requests are likely to be merged.

**As a general rule, most enhancement PRs will now be rejected.**

To save wasted effort, it is recommended that an issue is raised first.
The issue should clearly indicate that a PR is intended, and request approval for the work.

If you still want to raise a PR, please delete this text!
