### PR TITLE
improve exception message in DateTimeFormatter

### DIFF
--- a/src/main/java/org/joda/time/format/DateTimeFormat.java
+++ b/src/main/java/org/joda/time/format/DateTimeFormat.java
@@ -679,7 +679,7 @@ public class DateTimeFormat {
      */
     private static DateTimeFormatter createFormatterForPattern(String pattern) {
         if (pattern == null || pattern.length() == 0) {
-            throw new IllegalArgumentException("Invalid pattern specification");
+            throw new IllegalArgumentException("Invalid pattern specification. Pattern is null or empty.");
         }
         DateTimeFormatter formatter = cPatternCache.get(pattern);
         if (formatter == null) {


### PR DESCRIPTION
Hello, 
The proposed change is a very minor improvement to the exception message in DateTimeFormatter when the input is null or empty.

Current exception text: 
```
Invalid pattern specification
```

Proposed exception text:
```
Invalid pattern specification. Pattern is null or empty.
```

Rationale: 
An IllegalArgumentException is thrown if the pattern does not respect the ISO-8601 format OR if the pattern is null or empty.
The current exception text for null or empty case does not make it clear that the issue is not a ISO-8601 format issue but a null/empty issue. 
I lost some time on this when debugging. I think the proposed change can only improve the joda user experience, and does not add complexity to the codebase.

I did not open an issue, sorry about this, it was simpler to show the change in a PR.