### PR TITLE
Make `ConverterManager.getInstance()` init thread-safe.

### DIFF
--- a/src/main/java/org/joda/time/convert/ConverterManager.java
+++ b/src/main/java/org/joda/time/convert/ConverterManager.java
@@ -81,15 +81,14 @@ import org.joda.time.JodaTimePermission;
 public final class ConverterManager {
 
     /**
-     * Singleton instance, lazily loaded to avoid class loading.
+     * Holds the singleton instance, lazily loaded to avoid class loading.
      */
-    private static ConverterManager INSTANCE;
+    private static final class LazyConverterManagerHolder {
+        static final ConverterManager INSTANCE = new ConverterManager();
+    }
 
     public static ConverterManager getInstance() {
-        if (INSTANCE == null) {
-            INSTANCE = new ConverterManager();
-        }
-        return INSTANCE;
+        return LazyConverterManagerHolder.INSTANCE;
     }
     
     private ConverterSet iInstantConverters;

--- a/src/test/java/org/joda/time/convert/TestConverterManager.java
+++ b/src/test/java/org/joda/time/convert/TestConverterManager.java
@@ -127,9 +127,12 @@ public class TestConverterManager extends TestCase {
         Constructor con = cls.getDeclaredConstructor((Class[]) null);
         assertEquals(1, cls.getDeclaredConstructors().length);
         assertEquals(true, Modifier.isProtected(con.getModifiers()));
+
+        Class holderCls = Class.forName(cls.getName() + "$LazyConverterManagerHolder");
+        assertEquals(true, Modifier.isPrivate(holderCls.getModifiers()));
         
-        Field fld = cls.getDeclaredField("INSTANCE");
-        assertEquals(true, Modifier.isPrivate(fld.getModifiers()));
+        Field fld = holderCls.getDeclaredField("INSTANCE");
+        assertEquals(true, Modifier.isFinal(fld.getModifiers()));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
We encountered a TSAN error because 2 threads were racing to call
`ConverterManager.getInstance()`. My read is that the current code could
actually be unsafe, since one thread might see `INSTANCE` as non-null
before the other thread has initialized its fields.

Fortunately, this looks like a good case for [the
initialization-on-demand holder
idiom](https://www.cs.umd.edu/~pugh/java/memoryModel/jsr-133-faq.html#:~:text=initialization%20on%20demand%20holder%20idiom).

(There would be additional thread-safety concerns if anyone were to try
to _mutate_ the `ConverterManager` instance concurrently with usage. But
I'm not sure there's a solution to that short of spraying `synchronized`
around. That seems like probably overkill, given the possible
performance impact for what I'd hope is an uncommon use case.)
