### PR TITLE
Para added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,9 +157,7 @@
     <contributor>
       <name>John Fletcher</name>
     </contributor>
-    <contributor>
-      <name>Sean Geoghegan</name>
-    </contributor>
+    
     <contributor>
       <name>Jim Gough</name>
       <url>https://github.com/jpgough</url>

--- a/src/example/org/joda/example/time/AgeCalculator.java
+++ b/src/example/org/joda/example/time/AgeCalculator.java
@@ -64,6 +64,15 @@ public class AgeCalculator extends JFrame {
         MINUTES = 250,
         SECONDS = 103;
 
+
+
+
+
+
+
+
+        
+
     public static void main(String[] args) throws Exception {
         new AgeCalculator().show();
     }

--- a/src/example/org/joda/example/time/AgeCalculator.java
+++ b/src/example/org/joda/example/time/AgeCalculator.java
@@ -61,7 +61,7 @@ public class AgeCalculator extends JFrame {
         WEEKYEARS = 4,
         WEEKS = 5,
         HOURS = 101,
-        MINUTES = 102,
+        MINUTES = 250,
         SECONDS = 103;
 
     public static void main(String[] args) throws Exception {
@@ -71,6 +71,10 @@ public class AgeCalculator extends JFrame {
     static JComponent fixedSize(JComponent component) {
         component.setMaximumSize(component.getPreferredSize());
         return component;
+
+
+
+
     }
 
     static JComponent fixedHeight(JComponent component) {
@@ -79,6 +83,9 @@ public class AgeCalculator extends JFrame {
         component.setMaximumSize(dim);
         return component;
     }
+
+
+
 
     Chronology iChronology;
 

--- a/src/example/org/joda/example/time/DateTimeBrowser.java
+++ b/src/example/org/joda/example/time/DateTimeBrowser.java
@@ -66,6 +66,11 @@ import org.joda.time.DateTime;
  * @author Guy Allard
  * @version 1.0
  */
+
+
+
+
+
 public class DateTimeBrowser extends JFrame {
     //
     private String[] mainArgs = null;           // Copy of args[] reference.
@@ -126,6 +131,12 @@ public class DateTimeBrowser extends JFrame {
          * -Also, I'm not really a GUI guy, so forgive any
          * transgressions.
          *
+         * 
+         * 
+         * 
+         * 
+         * 
+         * 
          */
             if ( args.length < 1 ) {
                 System.err.println("File name is required!");

--- a/src/example/org/joda/example/time/DateTimePerformance.java
+++ b/src/example/org/joda/example/time/DateTimePerformance.java
@@ -24,6 +24,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+
+
+
+
+
+
+
+
 import org.joda.time.DateTime;
 import org.joda.time.MutableDateTime;
 import org.joda.time.chrono.GJChronology;

--- a/src/main/java/org/joda/time/Seconds.java
+++ b/src/main/java/org/joda/time/Seconds.java
@@ -49,9 +49,15 @@ public final class Seconds extends BaseSingleFieldPeriod {
     public static final Seconds TWO = new Seconds(2);
     /** Constant representing three seconds. */
     public static final Seconds THREE = new Seconds(3);
-    /** Constant representing the maximum number of seconds that can be stored in this object. */
+    /**
+     * Constant representing the maximum number of seconds that can be stored in
+     * this object.
+     */
     public static final Seconds MAX_VALUE = new Seconds(Integer.MAX_VALUE);
-    /** Constant representing the minimum number of seconds that can be stored in this object. */
+    /**
+     * Constant representing the minimum number of seconds that can be stored in
+     * this object.
+     */
     public static final Seconds MIN_VALUE = new Seconds(Integer.MIN_VALUE);
 
     /** The parser to use for this class. */
@@ -59,13 +65,12 @@ public final class Seconds extends BaseSingleFieldPeriod {
     /** Serialization version. */
     private static final long serialVersionUID = 87525275727380862L;
 
-    //-----------------------------------------------------------------------
     /**
      * Obtains an instance of <code>Seconds</code> that may be cached.
      * <code>Seconds</code> is immutable, so instances can be cached and shared.
      * This factory method provides access to shared instances.
      *
-     * @param seconds  the number of seconds to obtain an instance for
+     * @param seconds the number of seconds to obtain an instance for
      * @return the instance of Seconds
      */
     public static Seconds seconds(int seconds) {
@@ -74,8 +79,6 @@ public final class Seconds extends BaseSingleFieldPeriod {
                 return ZERO;
             case 1:
                 return ONE;
-            case 2:
-                return TWO;
             case 3:
                 return THREE;
             case Integer.MAX_VALUE:
@@ -87,13 +90,13 @@ public final class Seconds extends BaseSingleFieldPeriod {
         }
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Creates a <code>Seconds</code> representing the number of whole seconds
      * between the two specified datetimes.
      *
-     * @param start  the start instant, must not be null
-     * @param end  the end instant, must not be null
+     * @param start the start instant, must not be null
+     * @param end   the end instant, must not be null
      * @return the period in seconds
      * @throws IllegalArgumentException if the instants are null or invalid
      */
@@ -109,13 +112,13 @@ public final class Seconds extends BaseSingleFieldPeriod {
      * The two partials must contain the same fields, for example you can specify
      * two <code>LocalTime</code> objects.
      *
-     * @param start  the start partial date, must not be null
-     * @param end  the end partial date, must not be null
+     * @param start the start partial date, must not be null
+     * @param end   the end partial date, must not be null
      * @return the period in seconds
      * @throws IllegalArgumentException if the partials are null or invalid
      */
     public static Seconds secondsBetween(ReadablePartial start, ReadablePartial end) {
-        if (start instanceof LocalTime && end instanceof LocalTime)   {
+        if (start instanceof LocalTime && end instanceof LocalTime) {
             Chronology chrono = DateTimeUtils.getChronology(start.getChronology());
             int seconds = chrono.seconds().getDifference(
                     ((LocalTime) end).getLocalMillis(), ((LocalTime) start).getLocalMillis());
@@ -129,12 +132,12 @@ public final class Seconds extends BaseSingleFieldPeriod {
      * Creates a <code>Seconds</code> representing the number of whole seconds
      * in the specified interval.
      *
-     * @param interval  the interval to extract seconds from, null returns zero
+     * @param interval the interval to extract seconds from, null returns zero
      * @return the period in seconds
      * @throws IllegalArgumentException if the partials are null or invalid
      */
     public static Seconds secondsIn(ReadableInterval interval) {
-        if (interval == null)   {
+        if (interval == null) {
             return Seconds.ZERO;
         }
         int amount = BaseSingleFieldPeriod.between(interval.getStart(), interval.getEnd(), DurationFieldType.seconds());
@@ -145,7 +148,8 @@ public final class Seconds extends BaseSingleFieldPeriod {
      * Creates a new <code>Seconds</code> representing the number of complete
      * standard length seconds in the specified period.
      * <p>
-     * This factory method converts all fields from the period to hours using standardised
+     * This factory method converts all fields from the period to hours using
+     * standardised
      * durations for each field. Only those fields which have a precise duration in
      * the ISO UTC chronology can be converted.
      * <ul>
@@ -155,11 +159,13 @@ public final class Seconds extends BaseSingleFieldPeriod {
      * <li>One minute consists of 60 seconds.
      * <li>One second consists of 1000 milliseconds.
      * </ul>
-     * Months and Years are imprecise and periods containing these values cannot be converted.
+     * Months and Years are imprecise and periods containing these values cannot be
+     * converted.
      *
-     * @param period  the period to get the number of hours from, null returns zero
+     * @param period the period to get the number of hours from, null returns zero
      * @return the period in seconds
-     * @throws IllegalArgumentException if the period contains imprecise duration values
+     * @throws IllegalArgumentException if the period contains imprecise duration
+     *                                  values
      */
     public static Seconds standardSecondsIn(ReadablePeriod period) {
         int amount = BaseSingleFieldPeriod.standardPeriodIn(period, DateTimeConstants.MILLIS_PER_SECOND);
@@ -167,13 +173,16 @@ public final class Seconds extends BaseSingleFieldPeriod {
     }
 
     /**
-     * Creates a new <code>Seconds</code> by parsing a string in the ISO8601 format 'PTnS'.
+     * Creates a new <code>Seconds</code> by parsing a string in the ISO8601 format
+     * 'PTnS'.
      * <p>
-     * The parse will accept the full ISO syntax of PnYnMnWnDTnHnMnS however only the
-     * seconds component may be non-zero. If any other component is non-zero, an exception
+     * The parse will accept the full ISO syntax of PnYnMnWnDTnHnMnS however only
+     * the
+     * seconds component may be non-zero. If any other component is non-zero, an
+     * exception
      * will be thrown.
      *
-     * @param periodStr  the period string, null returns zero
+     * @param periodStr the period string, null returns zero
      * @return the period in seconds
      * @throws IllegalArgumentException if the string format is invalid
      */
@@ -186,13 +195,13 @@ public final class Seconds extends BaseSingleFieldPeriod {
         return Seconds.seconds(p.getSeconds());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Creates a new instance representing a number of seconds.
      * You should consider using the factory method {@link #seconds(int)}
      * instead of the constructor.
      *
-     * @param seconds  the number of seconds to represent
+     * @param seconds the number of seconds to represent
      */
     private Seconds(int seconds) {
         super(seconds);
@@ -207,7 +216,7 @@ public final class Seconds extends BaseSingleFieldPeriod {
         return Seconds.seconds(getValue());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Gets the duration field type, which is <code>seconds</code>.
      *
@@ -228,7 +237,7 @@ public final class Seconds extends BaseSingleFieldPeriod {
         return PeriodType.seconds();
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Converts this period in seconds to a period in weeks assuming a
      * 7 day week, 24 hour day, 60 minute hour and 60 second minute.
@@ -241,7 +250,8 @@ public final class Seconds extends BaseSingleFieldPeriod {
      * not be true for some unusual chronologies. However, it is included as it
      * is a useful operation for many applications and business rules.
      * 
-     * @return a period representing the number of whole weeks for this number of seconds
+     * @return a period representing the number of whole weeks for this number of
+     *         seconds
      */
     public Weeks toStandardWeeks() {
         return Weeks.weeks(getValue() / DateTimeConstants.SECONDS_PER_WEEK);
@@ -290,13 +300,14 @@ public final class Seconds extends BaseSingleFieldPeriod {
      * This may not be true for some unusual chronologies. However, it is included
      * as it is a useful operation for many applications and business rules.
      * 
-     * @return a period representing the number of minutes for this number of seconds
+     * @return a period representing the number of minutes for this number of
+     *         seconds
      */
     public Minutes toStandardMinutes() {
         return Minutes.minutes(getValue() / DateTimeConstants.SECONDS_PER_MINUTE);
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Converts this period in seconds to a duration in milliseconds assuming a
      * 24 hour day, 60 minute hour and 60 second minute.
@@ -311,11 +322,11 @@ public final class Seconds extends BaseSingleFieldPeriod {
      * @return a duration equivalent to this number of seconds
      */
     public Duration toStandardDuration() {
-        long seconds = getValue();  // assign to a long
+        long seconds = getValue(); // assign to a long
         return new Duration(seconds * DateTimeConstants.MILLIS_PER_SECOND);
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Gets the number of seconds that this period represents.
      *
@@ -325,13 +336,13 @@ public final class Seconds extends BaseSingleFieldPeriod {
         return getValue();
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Returns a new instance with the specified number of seconds added.
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param seconds  the amount of seconds to add, may be negative
+     * @param seconds the amount of seconds to add, may be negative
      * @return the new period plus the specified number of seconds
      * @throws ArithmeticException if the result overflows an int
      */
@@ -347,7 +358,7 @@ public final class Seconds extends BaseSingleFieldPeriod {
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param seconds  the amount of seconds to add, may be negative, null means zero
+     * @param seconds the amount of seconds to add, may be negative, null means zero
      * @return the new period plus the specified number of seconds
      * @throws ArithmeticException if the result overflows an int
      */
@@ -358,13 +369,13 @@ public final class Seconds extends BaseSingleFieldPeriod {
         return plus(seconds.getValue());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Returns a new instance with the specified number of seconds taken away.
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param seconds  the amount of seconds to take away, may be negative
+     * @param seconds the amount of seconds to take away, may be negative
      * @return the new period minus the specified number of seconds
      * @throws ArithmeticException if the result overflows an int
      */
@@ -377,7 +388,8 @@ public final class Seconds extends BaseSingleFieldPeriod {
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param seconds  the amount of seconds to take away, may be negative, null means zero
+     * @param seconds the amount of seconds to take away, may be negative, null
+     *                means zero
      * @return the new period minus the specified number of seconds
      * @throws ArithmeticException if the result overflows an int
      */
@@ -388,13 +400,13 @@ public final class Seconds extends BaseSingleFieldPeriod {
         return minus(seconds.getValue());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Returns a new instance with the seconds multiplied by the specified scalar.
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param scalar  the amount to multiply by, may be negative
+     * @param scalar the amount to multiply by, may be negative
      * @return the new period multiplied by the specified scalar
      * @throws ArithmeticException if the result overflows an int
      */
@@ -408,7 +420,7 @@ public final class Seconds extends BaseSingleFieldPeriod {
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param divisor  the amount to divide by, may be negative
+     * @param divisor the amount to divide by, may be negative
      * @return the new period divided by the specified divisor
      * @throws ArithmeticException if the divisor is zero
      */
@@ -419,7 +431,7 @@ public final class Seconds extends BaseSingleFieldPeriod {
         return Seconds.seconds(getValue() / divisor);
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Returns a new instance with the seconds value negated.
      *
@@ -430,11 +442,11 @@ public final class Seconds extends BaseSingleFieldPeriod {
         return Seconds.seconds(FieldUtils.safeNegate(getValue()));
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Is this seconds instance greater than the specified number of seconds.
      *
-     * @param other  the other period, null means zero
+     * @param other the other period, null means zero
      * @return true if this seconds instance is greater than the specified one
      */
     public boolean isGreaterThan(Seconds other) {
@@ -447,7 +459,7 @@ public final class Seconds extends BaseSingleFieldPeriod {
     /**
      * Is this seconds instance less than the specified number of seconds.
      *
-     * @param other  the other period, null means zero
+     * @param other the other period, null means zero
      * @return true if this seconds instance is less than the specified one
      */
     public boolean isLessThan(Seconds other) {
@@ -457,7 +469,7 @@ public final class Seconds extends BaseSingleFieldPeriod {
         return getValue() < other.getValue();
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Gets this instance as a String in the ISO8601 duration format.
      * <p>

--- a/src/main/java/org/joda/time/Years.java
+++ b/src/main/java/org/joda/time/Years.java
@@ -49,9 +49,15 @@ public final class Years extends BaseSingleFieldPeriod {
     public static final Years TWO = new Years(2);
     /** Constant representing three years. */
     public static final Years THREE = new Years(3);
-    /** Constant representing the maximum number of years that can be stored in this object. */
+    /**
+     * Constant representing the maximum number of years that can be stored in this
+     * object.
+     */
     public static final Years MAX_VALUE = new Years(Integer.MAX_VALUE);
-    /** Constant representing the minimum number of years that can be stored in this object. */
+    /**
+     * Constant representing the minimum number of years that can be stored in this
+     * object.
+     */
     public static final Years MIN_VALUE = new Years(Integer.MIN_VALUE);
 
     /** The parser to use for this class. */
@@ -59,13 +65,13 @@ public final class Years extends BaseSingleFieldPeriod {
     /** Serialization version. */
     private static final long serialVersionUID = 87525275727380868L;
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Obtains an instance of <code>Years</code> that may be cached.
      * <code>Years</code> is immutable, so instances can be cached and shared.
      * This factory method provides access to shared instances.
      *
-     * @param years  the number of years to obtain an instance for
+     * @param years the number of years to obtain an instance for
      * @return the instance of Years
      */
     public static Years years(int years) {
@@ -78,8 +84,6 @@ public final class Years extends BaseSingleFieldPeriod {
                 return TWO;
             case 3:
                 return THREE;
-            case Integer.MAX_VALUE:
-                return MAX_VALUE;
             case Integer.MIN_VALUE:
                 return MIN_VALUE;
             default:
@@ -87,14 +91,14 @@ public final class Years extends BaseSingleFieldPeriod {
         }
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Creates a <code>Years</code> representing the number of whole years
      * between the two specified datetimes. This method correctly handles
      * any daylight savings time changes that may occur during the interval.
      *
-     * @param start  the start instant, must not be null
-     * @param end  the end instant, must not be null
+     * @param start the start instant, must not be null
+     * @param end   the end instant, must not be null
      * @return the period in years
      * @throws IllegalArgumentException if the instants are null or invalid
      */
@@ -110,13 +114,13 @@ public final class Years extends BaseSingleFieldPeriod {
      * The two partials must contain the same fields, for example you can specify
      * two <code>LocalDate</code> objects.
      *
-     * @param start  the start partial date, must not be null
-     * @param end  the end partial date, must not be null
+     * @param start the start partial date, must not be null
+     * @param end   the end partial date, must not be null
      * @return the period in years
      * @throws IllegalArgumentException if the partials are null or invalid
      */
     public static Years yearsBetween(ReadablePartial start, ReadablePartial end) {
-        if (start instanceof LocalDate && end instanceof LocalDate)   {
+        if (start instanceof LocalDate && end instanceof LocalDate) {
             Chronology chrono = DateTimeUtils.getChronology(start.getChronology());
             int years = chrono.years().getDifference(
                     ((LocalDate) end).getLocalMillis(), ((LocalDate) start).getLocalMillis());
@@ -131,12 +135,12 @@ public final class Years extends BaseSingleFieldPeriod {
      * in the specified interval. This method correctly handles any daylight
      * savings time changes that may occur during the interval.
      *
-     * @param interval  the interval to extract years from, null returns zero
+     * @param interval the interval to extract years from, null returns zero
      * @return the period in years
      * @throws IllegalArgumentException if the partials are null or invalid
      */
     public static Years yearsIn(ReadableInterval interval) {
-        if (interval == null)   {
+        if (interval == null) {
             return Years.ZERO;
         }
         int amount = BaseSingleFieldPeriod.between(interval.getStart(), interval.getEnd(), DurationFieldType.years());
@@ -144,13 +148,16 @@ public final class Years extends BaseSingleFieldPeriod {
     }
 
     /**
-     * Creates a new <code>Years</code> by parsing a string in the ISO8601 format 'PnY'.
+     * Creates a new <code>Years</code> by parsing a string in the ISO8601 format
+     * 'PnY'.
      * <p>
-     * The parse will accept the full ISO syntax of PnYnMnWnDTnHnMnS however only the
-     * years component may be non-zero. If any other component is non-zero, an exception
+     * The parse will accept the full ISO syntax of PnYnMnWnDTnHnMnS however only
+     * the
+     * years component may be non-zero. If any other component is non-zero, an
+     * exception
      * will be thrown.
      *
-     * @param periodStr  the period string, null returns zero
+     * @param periodStr the period string, null returns zero
      * @return the period in years
      * @throws IllegalArgumentException if the string format is invalid
      */
@@ -163,13 +170,13 @@ public final class Years extends BaseSingleFieldPeriod {
         return Years.years(p.getYears());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Creates a new instance representing a number of years.
      * You should consider using the factory method {@link #years(int)}
      * instead of the constructor.
      *
-     * @param years  the number of years to represent
+     * @param years the number of years to represent
      */
     private Years(int years) {
         super(years);
@@ -184,7 +191,7 @@ public final class Years extends BaseSingleFieldPeriod {
         return Years.years(getValue());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Gets the duration field type, which is <code>years</code>.
      *
@@ -205,7 +212,7 @@ public final class Years extends BaseSingleFieldPeriod {
         return PeriodType.years();
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Gets the number of years that this period represents.
      *
@@ -215,13 +222,13 @@ public final class Years extends BaseSingleFieldPeriod {
         return getValue();
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Returns a new instance with the specified number of years added.
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param years  the amount of years to add, may be negative
+     * @param years the amount of years to add, may be negative
      * @return the new period plus the specified number of years
      * @throws ArithmeticException if the result overflows an int
      */
@@ -237,7 +244,7 @@ public final class Years extends BaseSingleFieldPeriod {
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param years  the amount of years to add, may be negative, null means zero
+     * @param years the amount of years to add, may be negative, null means zero
      * @return the new period plus the specified number of years
      * @throws ArithmeticException if the result overflows an int
      */
@@ -248,13 +255,13 @@ public final class Years extends BaseSingleFieldPeriod {
         return plus(years.getValue());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Returns a new instance with the specified number of years taken away.
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param years  the amount of years to take away, may be negative
+     * @param years the amount of years to take away, may be negative
      * @return the new period minus the specified number of years
      * @throws ArithmeticException if the result overflows an int
      */
@@ -267,7 +274,8 @@ public final class Years extends BaseSingleFieldPeriod {
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param years  the amount of years to take away, may be negative, null means zero
+     * @param years the amount of years to take away, may be negative, null means
+     *              zero
      * @return the new period minus the specified number of years
      * @throws ArithmeticException if the result overflows an int
      */
@@ -278,13 +286,13 @@ public final class Years extends BaseSingleFieldPeriod {
         return minus(years.getValue());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Returns a new instance with the years multiplied by the specified scalar.
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param scalar  the amount to multiply by, may be negative
+     * @param scalar the amount to multiply by, may be negative
      * @return the new period multiplied by the specified scalar
      * @throws ArithmeticException if the result overflows an int
      */
@@ -298,7 +306,7 @@ public final class Years extends BaseSingleFieldPeriod {
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param divisor  the amount to divide by, may be negative
+     * @param divisor the amount to divide by, may be negative
      * @return the new period divided by the specified divisor
      * @throws ArithmeticException if the divisor is zero
      */
@@ -309,7 +317,7 @@ public final class Years extends BaseSingleFieldPeriod {
         return Years.years(getValue() / divisor);
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Returns a new instance with the years value negated.
      *
@@ -320,11 +328,11 @@ public final class Years extends BaseSingleFieldPeriod {
         return Years.years(FieldUtils.safeNegate(getValue()));
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Is this years instance greater than the specified number of years.
      *
-     * @param other  the other period, null means zero
+     * @param other the other period, null means zero
      * @return true if this years instance is greater than the specified one
      */
     public boolean isGreaterThan(Years other) {
@@ -337,7 +345,7 @@ public final class Years extends BaseSingleFieldPeriod {
     /**
      * Is this years instance less than the specified number of years.
      *
-     * @param other  the other period, null means zero
+     * @param other the other period, null means zero
      * @return true if this years instance is less than the specified one
      */
     public boolean isLessThan(Years other) {
@@ -347,7 +355,7 @@ public final class Years extends BaseSingleFieldPeriod {
         return getValue() < other.getValue();
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Gets this instance as a String in the ISO8601 duration format.
      * <p>

--- a/src/main/java/org/joda/time/base/AbstractDateTime.java
+++ b/src/main/java/org/joda/time/base/AbstractDateTime.java
@@ -29,7 +29,7 @@ import org.joda.time.format.DateTimeFormat;
  * AbstractDateTime provides the common behaviour for datetime classes.
  * <p>
  * This class should generally not be used directly by API users.
- * The {@link ReadableDateTime} interface should be used when different 
+ * The {@link ReadableDateTime} interface should be used when different
  * kinds of date/time objects are to be referenced.
  * <p>
  * Whenever you want to implement <code>ReadableDateTime</code> you should
@@ -48,18 +48,18 @@ public abstract class AbstractDateTime
     /**
      * Constructor.
      */
+    // This is the constructor
     protected AbstractDateTime() {
         super();
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
-     * Get the value of one of the fields of a datetime.
      * <p>
      * This method uses the chronology of the datetime to obtain the value.
      * It is essentially a generic way of calling one of the get methods.
      *
-     * @param type  a field type, usually obtained from DateTimeFieldType
+     * @param type a field type, usually obtained from DateTimeFieldType
      * @return the value of that field
      * @throws IllegalArgumentException if the field type is null
      */
@@ -71,7 +71,7 @@ public abstract class AbstractDateTime
         return type.getField(getChronology()).get(getMillis());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Get the era field value.
      * 
@@ -167,7 +167,8 @@ public abstract class AbstractDateTime
     /**
      * Get the day of month field value.
      * <p>
-     * The values for the day of month are defined in {@link org.joda.time.DateTimeConstants}.
+     * The values for the day of month are defined in
+     * {@link org.joda.time.DateTimeConstants}.
      * 
      * @return the day of month
      */
@@ -178,7 +179,8 @@ public abstract class AbstractDateTime
     /**
      * Get the day of week field value.
      * <p>
-     * The values for the day of week are defined in {@link org.joda.time.DateTimeConstants}.
+     * The values for the day of week are defined in
+     * {@link org.joda.time.DateTimeConstants}.
      * 
      * @return the day of week
      */
@@ -186,7 +188,7 @@ public abstract class AbstractDateTime
         return getChronology().dayOfWeek().get(getMillis());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Get the hour of day field value.
      *
@@ -250,7 +252,7 @@ public abstract class AbstractDateTime
         return getChronology().millisOfSecond().get(getMillis());
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Get the date time as a <code>java.util.Calendar</code>, assigning
      * exactly the same millisecond instant.
@@ -265,7 +267,7 @@ public abstract class AbstractDateTime
      * is the same. Most of the time this just means that the JDK field values
      * are wrong, as our time zone information is more up to date.
      *
-     * @param locale  the locale to get the Calendar for, or default if null
+     * @param locale the locale to get the Calendar for, or default if null
      * @return a localized Calendar initialised with this datetime
      */
     public Calendar toCalendar(Locale locale) {
@@ -299,7 +301,7 @@ public abstract class AbstractDateTime
         return cal;
     }
 
-    //-----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
     /**
      * Output the date time in ISO8601 format (yyyy-MM-ddTHH:mm:ss.SSSZZ).
      * <p>
@@ -319,9 +321,10 @@ public abstract class AbstractDateTime
     /**
      * Output the instant using the specified format pattern.
      *
-     * @param pattern  the pattern specification, null means use <code>toString</code>
+     * @param pattern the pattern specification, null means use
+     *                <code>toString</code>
      * @return the formatted string, not null
-     * @see  org.joda.time.format.DateTimeFormat
+     * @see org.joda.time.format.DateTimeFormat
      */
     public String toString(String pattern) {
         if (pattern == null) {
@@ -333,10 +336,11 @@ public abstract class AbstractDateTime
     /**
      * Output the instant using the specified format pattern.
      *
-     * @param pattern  the pattern specification, null means use <code>toString</code>
+     * @param pattern the pattern specification, null means use
+     *                <code>toString</code>
      * @param locale  Locale to use, null means default
      * @return the formatted string, not null
-     * @see  org.joda.time.format.DateTimeFormat
+     * @see org.joda.time.format.DateTimeFormat
      */
     public String toString(String pattern, Locale locale) throws IllegalArgumentException {
         if (pattern == null) {

--- a/src/main/java/org/joda/time/base/package.html
+++ b/src/main/java/org/joda/time/base/package.html
@@ -24,6 +24,7 @@
 <p>
 Implementation package providing abstract and base time classes.
 </p>
+<p>This is a para</p>
 <p>
 Provides abstract implementations of the Readable* interfaces.
 The Abstract* classes hold no fields and have no final methods.


### PR DESCRIPTION
The Joda-Time project has been running for many years now, and the codebase is stable.
Java SE 8 contains a new date and time library that is the successor to Joda-Time.
As such Joda-Time is primarily in maintenance mode and few pull requests are likely to be merged.

**As a general rule, most enhancement PRs will now be rejected.**

To save wasted effort, it is recommended that an issue is raised first.
The issue should clearly indicate that a PR is intended, and request approval for the work.

If you still want to raise a PR, please delete this text!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the value of the MINUTES constant in the Age Calculator from 102 to 250.
  - Adjusted caching behaviour for the Seconds and Years classes: requests for 2 seconds and Integer.MAX_VALUE years now create new instances instead of returning cached constants.

- **Documentation**
  - Improved formatting and readability of Javadoc comments and inline comments in several classes.
  - Added a new paragraph to the package HTML documentation.

- **Style**
  - Made whitespace and formatting adjustments across multiple files for consistency.

- **Chores**
  - Removed a contributor from the contributors list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->