### PR TITLE
Update deployment from OSSRH

### DIFF
--- a/.github/maven-settings.xml
+++ b/.github/maven-settings.xml
@@ -4,9 +4,9 @@
                           https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>sonatype-joda-staging</id>
-      <username>${env.OSSRH_USERNAME}</username>
-      <password>${env.OSSRH_TOKEN}</password>
+      <id>central-publish</id>
+      <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+      <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
     </server>
     <server>
       <id>github</id>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,20 +12,17 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  security-events: write  # for github/codeql-action
+  contents: read
 
 jobs:
   build:
+    permissions:
+      security-events: write  # for github/codeql-action
     runs-on: ubuntu-latest
-    env:
-      MAVEN_ARGS: -e -B -ntp -DtrimStackTrace=false
 
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
-      with:
-        token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
 
     - name: Set up JDK
       uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12  #v4.7.0
@@ -36,9 +33,17 @@ jobs:
 
     - name: Maven version
       run: |
+        mkdir -p ./.mvn
+        echo "-e" >> ./.mvn/maven.config
+        echo "-B" >> ./.mvn/maven.config
+        echo "-ntp" >> ./.mvn/maven.config
+        echo "-DtrimStackTrace=false" >> ./.mvn/maven.config
+        echo "--settings" >> ./.mvn/maven.config
+        echo "$( pwd )/.github/maven-settings.xml" >> ./.mvn/maven.config
         mvn --version
         mkdir -p target
 
+    #------------------------------------------------------------------------
     - name: Initialize CodeQL
       uses: github/codeql-action/init@70df9def86d22bf0ea4e7f8b956e7b92e7c1ea22  #codeql-bundle-v2.20.7
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      MAVEN_ARGS: -e -B -ntp -DtrimStackTrace=false
-
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
@@ -38,6 +35,10 @@ jobs:
     - name: Maven version
       run: |
         mkdir -p ./.mvn
+        echo "-e" >> ./.mvn/maven.config
+        echo "-B" >> ./.mvn/maven.config
+        echo "-ntp" >> ./.mvn/maven.config
+        echo "-DtrimStackTrace=false" >> ./.mvn/maven.config
         echo "--settings" >> ./.mvn/maven.config
         echo "$( pwd )/.github/maven-settings.xml" >> ./.mvn/maven.config
         mvn --version
@@ -46,8 +47,8 @@ jobs:
     #------------------------------------------------------------------------
     - name: Maven release
       env:
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
         MAVEN_GPG_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
         GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
@@ -59,6 +60,7 @@ jobs:
         git tag websiterelease
         git push origin websiterelease
 
+    # delete the initiating tag, but not if the build is manually initialized by workflow_dispatch
     - name: Delete release tag
       if: "always() && github.ref != 'refs/heads/main'"
       run: |

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -12,18 +12,16 @@ permissions:
 jobs:
   website:
     runs-on: ubuntu-latest
-    env:
-      MAVEN_ARGS: -e -B -ntp -DtrimStackTrace=false
-
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  #v4.2.2
       with:
         token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+        ref: ${{ github.ref }}
+        fetch-tags: true
 
     - name: Setup git
       run: |
-        git fetch --tags
         git config --global user.name "Stephen Colebourne (CI)"
         git config --global user.email "scolebourne@joda.org"
 
@@ -36,6 +34,13 @@ jobs:
 
     - name: Maven version
       run: |
+        mkdir -p ./.mvn
+        echo "-e" >> ./.mvn/maven.config
+        echo "-B" >> ./.mvn/maven.config
+        echo "-ntp" >> ./.mvn/maven.config
+        echo "-DtrimStackTrace=false" >> ./.mvn/maven.config
+        echo "--settings" >> ./.mvn/maven.config
+        echo "$( pwd )/.github/maven-settings.xml" >> ./.mvn/maven.config
         mvn --version
         mkdir -p target
 
@@ -66,8 +71,9 @@ jobs:
 
         git push origin main
 
+    # delete the initiating tag, but not if the build is manually initialized by workflow_dispatch
     - name: Delete website tag
-      if: github.ref != 'refs/heads/main'
+      if: "always() && github.ref != 'refs/heads/main'"
       run: |
         git tag --delete "${GITHUB_REF_NAME}" || true
         git push --delete origin "${GITHUB_REF_NAME}" || true

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Note that Joda-Time is considered to be a largely “finished” project. No maj
 
 Release from local:
 
-* Turn off gpg "bc" signer
+* Ensure `gpg-agent` is running
 * Ensure on Java SE 8
 * `mvn clean deploy -Doss.repo -Dgpg.passphrase=""`
 * Website will be built and released by GitHub Actions

--- a/pom.xml
+++ b/pom.xml
@@ -804,14 +804,14 @@
     <dependency>
       <groupId>org.joda</groupId>
       <artifactId>joda-convert</artifactId>
-      <version>1.9.2</version>
+      <version>${joda-convert.version}</version>
       <scope>compile</scope>
       <optional>true</optional><!-- mandatory in Scala -->
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -878,24 +878,6 @@
   </reporting>
 
   <!-- ==================================================================== -->
-  <distributionManagement>
-    <repository>
-      <id>sonatype-joda-staging</id>
-      <name>Sonatype OSS staging repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-      <layout>default</layout>
-    </repository>
-    <snapshotRepository>
-      <uniqueVersion>false</uniqueVersion>
-      <id>sonatype-joda-snapshot</id>
-      <name>Sonatype OSS snapshot repository</name>
-      <url>https://oss.sonatype.org/content/repositories/joda-snapshots</url>
-      <layout>default</layout>
-    </snapshotRepository>
-    <downloadUrl>https://oss.sonatype.org/content/repositories/joda-releases</downloadUrl>
-  </distributionManagement>
-
-  <!-- ==================================================================== -->
   <profiles>
     <!-- Need earlier surefire plugin for Java 5 support -->
     <profile>
@@ -920,6 +902,19 @@
         <doclint>none</doclint>
       </properties>
     </profile>
+    <!-- Set environment when running on GitHub Actions -->
+    <profile>
+      <id>github-action</id>
+      <activation>
+        <property>
+          <name>env.GITHUB_ACTIONS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <gpg.signer>bc</gpg.signer>
+      </properties>
+    </profile>
     <!-- Base deployment profile, activated by -Doss.repo -->
     <!-- Release should be performed using a Java 8 JVM -->
     <profile>
@@ -931,22 +926,22 @@
       </activation>
       <build>
         <plugins>
-          <!-- Use nexus plugin to directly release -->
+          <!-- Use central plugin to directly release (see comment about ordering below) -->
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central-publishing-maven-plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <serverId>sonatype-joda-staging</serverId>
-              <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central-publish</publishingServerId>
+              <deploymentName>${project.name}</deploymentName>
+              <autoPublish>${joda.publish.auto}</autoPublish>
+              <waitUntil>${joda.publish.wait}</waitUntil>
             </configuration>
           </plugin>
           <!-- Create dist files -->
           <!-- Since we cannot sign a single file, we put everything in the deploy phase -->
-          <!-- The standard files are signed in the verify phase and then deployed to Maven Central using nexus-staging-maven-plugin -->
+          <!-- The standard files are signed in the verify phase and then deployed to Maven Central using central-publishing-maven-plugin -->
           <!-- Then (and only then) we create and attach the dist files, sign them, and release them to GitHub Releases -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -978,20 +973,14 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
-                <configuration>
-                  <signer>bc</signer>
-                </configuration>
               </execution>
-              <!-- this execution must be located after nexus-staging-maven-plugin (see comment above about ordering) -->
+              <!-- this execution must be located after central-publishing-maven-plugin (see comment above about ordering) -->
               <execution>
                 <id>sign-dist-artifacts</id>
                 <phase>deploy</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>
-                <configuration>
-                  <signer>bc</signer>
-                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -999,7 +988,7 @@
           <plugin>
             <groupId>de.jutzig</groupId>
             <artifactId>github-release-plugin</artifactId>
-            <version>1.6.0</version>
+            <version>${github-release-plugin.version}</version>
             <executions>
               <execution>
                 <id>github-releases</id>
@@ -1073,13 +1062,20 @@
 
   <!-- ==================================================================== -->
   <properties>
+    <!-- Dependencies -->
+    <joda-convert.version>1.9.2</joda-convert.version>
+    <junit.version>3.8.2</junit.version>
+
+    <!-- Common control parameters -->
+    <joda.publish.auto>false</joda.publish.auto><!-- false/true -->
+    <joda.publish.wait>validated</joda.publish.wait><!-- validated/published -->
+
     <!-- Plugin version numbers -->
-    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
-    <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
+    <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
     <maven-changes-plugin.version>2.12.1</maven-changes-plugin.version>
     <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
@@ -1099,8 +1095,10 @@
     <!-- Stick with this version of surefire, see Java 5 comments above -->
     <maven-surefire-report-plugin.version>2.21.0</maven-surefire-report-plugin.version>
     <maven-toolchains-plugin.version>3.1.0</maven-toolchains-plugin.version>
+    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
     <github-api.version>1.326</github-api.version>
-    <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
+    <github-release-plugin.version>1.6.0</github-release-plugin.version>
 
     <!-- Properties for maven-compiler-plugin -->
     <maven.compiler.compilerVersion>1.5</maven.compiler.compilerVersion>


### PR DESCRIPTION
OSSRH is dead, use replacement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migrate publishing to Maven Central’s modern flow for more reliable releases.

* **Chores**
  * Tighten CI permissions, remove personal access token usage, and standardise Maven invocation across workflows.
  * Update CI credential names and release/website automation behaviour.
  * Upgrade build plugins, move dependency versions to properties, and adjust signing/publishing steps.

* **Documentation**
  * Local release notes updated to require a running gpg-agent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->